### PR TITLE
fix(ext): remove inline script (CSP violation) + CI enforcement (Closes #189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
           test -f extension/sidepanel.html || (echo "extension/sidepanel.html missing!" && exit 1)
           echo "L8 OK: extension artifacts present"
 
+      - name: Check no inline scripts in HTML (CSP compliance)
+        run: |
+          if grep -rn '<script[^>]*>[^<]' extension/*.html 2>/dev/null | grep -v 'src='; then
+            echo "CSP VIOLATION: inline <script> found in HTML"
+            exit 1
+          fi
+          echo "CSP OK: no inline scripts"
+
       - name: cargo clippy (L3 law — zero warnings)
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2960,7 +2977,6 @@ dependencies = [
  "anyhow",
  "clap",
  "git2",
- "libc",
  "regex",
  "reqwest 0.11.27",
  "rusqlite",
@@ -3015,6 +3031,7 @@ dependencies = [
  "serde",
  "serde_json",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 
@@ -3479,6 +3496,45 @@ checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "wasm-encoder"

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -1,18 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Trios — Queen Trinity Sidebar</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trios</title>
 </head>
 <body>
-  <script type="module">
-    import init, { run } from './dist/wasm/trios_ext.js';
-    async function main() {
-      await init('./dist/wasm/trios_ext_bg.wasm');
-      run();
-    }
-    main();
-  </script>
+  <div id="root"></div>
+  <script src="dist/bootstrap.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the CSP violation in `extension/sidepanel.html` that causes Chrome to block the extension with "Executing inline script violates CSP directive 'script-src self'".

### Changes

| File | Change |
|------|--------|
| `extension/sidepanel.html` | Remove inline `<script type="module">` → use `<script src="dist/bootstrap.js" type="module">` |
| `.github/workflows/ci.yml` | Add CI check: reject inline `<script>` in HTML files |

### Root Cause

The previous PR merged inline `<script type="module">` with `import init from './dist/wasm/trios_ext.js'` directly inside `sidepanel.html`. Chrome MV3 CSP blocks inline scripts → white screen.

### Fix

- HTML now only references external script: `<script src="dist/bootstrap.js" type="module">`
- `dist/bootstrap.js` is a 3-line init stub (the only `.js` allowed outside `dist/wasm/`)
- CI physically blocks future inline scripts via `grep` check

### Verification

```
cargo test -p trios-ext → 5/5 passed
cargo clippy -p trios-ext --target wasm32-unknown-unknown -- -D warnings → 0 warnings
grep '<script[^>]*>[^<]' extension/*.html | grep -v 'src=' → empty (no inline scripts)
```

Closes #189
Refs #156