### PR TITLE
fix(trios-ext): add CSP for wasm-unsafe-eval in manifest.json

### DIFF
--- a/crates/trios-ext/extension/manifest.json
+++ b/crates/trios-ext/extension/manifest.json
@@ -24,5 +24,8 @@
     "32": "assets/icons/icon-32.png",
     "48": "assets/icons/icon-48.png",
     "128": "assets/icons/icon-128.png"
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' ws://localhost:9005"
   }
 }


### PR DESCRIPTION
## Summary

Fix Chrome Extension CSP to allow WebAssembly instantiation in the Trios extension.

`WebAssembly.compile` was failing in `trios-ext` because MV3 `extension_pages` CSP does not permit `wasm-unsafe-eval` by default. Without this directive the WASM bridge (L8 Comet Bridge) cannot load and the sidepanel fails at startup.

## Change

Added `content_security_policy.extension_pages` to `crates/trios-ext/extension/manifest.json`:

```
"content_security_policy": {
  "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' ws://localhost:9005"
}
```

- `script-src 'self' 'wasm-unsafe-eval'` — required for Rust + WASM runtime
- `connect-src 'self' ws://localhost:9005` — matches `host_permissions` for the MCP bridge to `trios-server`
- `object-src 'self'` — MV3 default hardening

## Trinity Stack Laws

- L1 (Atomic PR): single file change, single scope (trios-ext manifest/CSP). No mixed scopes.
- L1 (no .sh): no shell scripts touched/added.
- L7 (tests): manifest-only change, no runtime logic; verified by loading the unpacked extension.
- L8 (PUSH FIRST): pushed to `fix/trios-ext-csp-wasm-unsafe-eval` before PR.

## Gates

- [x] `cargo fmt` — N/A (JSON only)
- [x] `cargo clippy -D warnings` — N/A (JSON only)
- [x] `cargo test` — unaffected
- [x] wasm32 build — unaffected
- [x] no inline JS introduced

## Related

Unblocks L8 Comet Bridge runtime (refs #157).