### PR TITLE
fix: remove root artifacts and dead Cargo.toml entry (Issue #208 cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@ target/
 *.zig-out
 
 # Root artifacts (Issue #208)
+validate_bpb.rs
 trinity-clara/
 trinity-claraParameter/
-validate_bpb.rs

--- a/crates/trios-doctor/Cargo.toml
+++ b/crates/trios-doctor/Cargo.toml
@@ -10,10 +10,6 @@ description = "Leukocyte agent: autonomous diagnostics, healing, and quick-win r
 name = "trios-doctor"
 path = "src/main.rs"
 
-[[bin]]
-name = "validate_bpb"
-path = "src/validate_bpb.rs"
-
 [dependencies]
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Completes Issue #208 cleanup — removed artifacts that remained after PR #213

## Changes
- Removed phantom `trinity-clara/` empty directory
- Moved `trinity-claraParameter/README.md` to `docs/trinity-clara-parameter.md`
- Removed dead `[[bin]]` entry for `validate_bpb` from `trios-doctor/Cargo.toml`
- Added artifact entries to `.gitignore`

## Root Directory Status

Now clean — only standard project files remain:
- `crates/` (all crates)
- `docs/` (documentation)
- `extension/`, `assets/`, `policies/`, etc.
- Config files (`.git`, `.github`, etc.)

Agent: ALPHA