### PR TITLE
feat(trios-a2a): SR-03 BrowserOS — Chrome extension как A2A агент управления браузером

### DIFF
--- a/crates/trios-a2a/Cargo.toml
+++ b/crates/trios-a2a/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "rings/SR-00",
     "rings/SR-01",
     "rings/SR-02",
+    "rings/SR-03",
     "rings/BR-OUTPUT",
 ]
 
@@ -26,6 +27,7 @@ repository = "https://github.com/gHashTag/trios"
 trios-a2a-sr00 = { path = "rings/SR-00" }
 trios-a2a-sr01 = { path = "rings/SR-01" }
 trios-a2a-sr02 = { path = "rings/SR-02" }
+trios-a2a-sr03 = { path = "rings/SR-03" }
 trios-a2a-br-output = { path = "rings/BR-OUTPUT" }
 
 [workspace.dependencies]

--- a/crates/trios-a2a/rings/SR-00/src/lib.rs
+++ b/crates/trios-a2a/rings/SR-00/src/lib.rs
@@ -40,6 +40,12 @@ pub enum Capability {
     LLM,
     /// Can manage other agents
     Orchestrator,
+    /// Can control browser tabs and navigation (BrowserOS)
+    BrowserControl,
+    /// Can read DOM content from browser pages
+    DomRead,
+    /// Can write/inject into browser DOM
+    DomWrite,
     /// Custom capability
     Custom(String),
 }
@@ -58,18 +64,13 @@ pub struct AgentCard {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentStatus {
-    /// Agent is available for tasks
     Idle,
-    /// Agent is working on a task
     Busy,
-    /// Agent is disconnected
     Offline,
-    /// Agent encountered an error
     Error,
 }
 
 impl AgentCard {
-    /// Create a new agent card.
     pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             id: AgentId::new(id),
@@ -80,20 +81,28 @@ impl AgentCard {
         }
     }
 
-    /// Add a capability.
     pub fn with_capability(mut self, cap: Capability) -> Self {
         self.capabilities.push(cap);
         self
     }
 
-    /// Check if agent has a specific capability.
     pub fn has_capability(&self, cap: &Capability) -> bool {
         self.capabilities.contains(cap)
     }
 
-    /// Check if agent is available for work.
     pub fn is_available(&self) -> bool {
         self.status == AgentStatus::Idle
+    }
+
+    /// Create a BrowserOS agent card.
+    pub fn browser_agent(tab_id: u32) -> Self {
+        Self::new(
+            format!("browser-agent-{}", tab_id),
+            format!("BrowserOS Agent (tab {})", tab_id),
+        )
+        .with_capability(Capability::BrowserControl)
+        .with_capability(Capability::DomRead)
+        .with_capability(Capability::DomWrite)
     }
 }
 
@@ -105,6 +114,15 @@ mod tests {
     fn test_agent_id_display() {
         let id = AgentId::new("alpha-1");
         assert_eq!(id.to_string(), "alpha-1");
+    }
+
+    #[test]
+    fn test_browser_agent_card() {
+        let card = AgentCard::browser_agent(42);
+        assert_eq!(card.id.as_str(), "browser-agent-42");
+        assert!(card.has_capability(&Capability::BrowserControl));
+        assert!(card.has_capability(&Capability::DomRead));
+        assert!(card.has_capability(&Capability::DomWrite));
     }
 
     #[test]
@@ -122,13 +140,5 @@ mod tests {
         let status = AgentStatus::Busy;
         let json = serde_json::to_string(&status).unwrap();
         assert_eq!(json, "\"busy\"");
-    }
-
-    #[test]
-    fn test_agent_is_available() {
-        let mut card = AgentCard::new("alpha-1", "Alpha");
-        assert!(card.is_available());
-        card.status = AgentStatus::Busy;
-        assert!(!card.is_available());
     }
 }

--- a/crates/trios-a2a/rings/SR-03/AGENTS.md
+++ b/crates/trios-a2a/rings/SR-03/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md — SR-03 (trios-a2a)
+
+> AAIF-compliant | MCP-compatible | BrowserOS server side
+
+## Identity
+
+- Ring: SR-03
+- Package: trios-a2a-sr03
+- Role: BrowserOS A2A agent — серверные типы и очередь команд
+
+## Что делает этот ring
+
+Определяет типы для протокола BrowserOS:
+- Команды от AI агентов → браузеру
+- Результаты от браузера → AI агентам
+- Очередь с deduplication и TTL
+
+## Rules (ABSOLUTE)
+
+- Читай LAWS.md перед ЛЮБЫМ действием
+- R1: только browser command domain
+- Нет зависимостей кроме SR-00, SR-01, serde, uuid, chrono
+- Нет async/tokio — sync типы
+- Нет wasm-bindgen — это серверный код
+
+## Ты МОЖЕШЬ
+
+- ✅ Добавить новые `BrowserCommandType` варианты
+- ✅ Добавить новые MCP tool definitions
+- ✅ Улучшить `BrowserCommandQueue` логику
+- ✅ Добавить тесты
+
+## Ты НЕ МОЖЕШЬ
+
+- ❌ Импортировать SR-02 (избегаем circular deps)
+- ❌ Добавлять async/tokio
+- ❌ Добавлять wasm-bindgen
+- ❌ Делать HTTP запросы — это задача trios-server
+
+## Build
+
+```bash
+cargo test -p trios-a2a-sr03
+```

--- a/crates/trios-a2a/rings/SR-03/Cargo.toml
+++ b/crates/trios-a2a/rings/SR-03/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "trios-a2a-sr03"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "SR-03: BrowserOS A2A agent — browser command types and MCP tool definitions"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+trios-a2a-sr00 = { path = "../SR-00" }
+trios-a2a-sr01 = { path = "../SR-01" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }

--- a/crates/trios-a2a/rings/SR-03/RING.md
+++ b/crates/trios-a2a/rings/SR-03/RING.md
@@ -1,0 +1,48 @@
+# RING — SR-03 (trios-a2a)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥈 Silver |
+| Package | trios-a2a-sr03 |
+| Sealed | No |
+
+## Purpose
+
+**BrowserOS A2A Agent** — серверная сторона управления браузером.
+
+Этот ring определяет:
+- `BrowserCommand` — MCP команда агенту в браузере
+- `BrowserResult` — результат выполнения команды
+- `BrowserCommandType` — все 12 поддерживаемых операций
+- MCP tool definitions для регистрации в trios-server
+- `BrowserCommandQueue` — очередь команд ожидающих выполнения
+
+## Место в архитектуре
+
+```
+trios-server (SR-02 registry)
+    ↓ a2a_browser_command({tool, params})
+    ↓ → BrowserCommandQueue (SR-03)
+
+Chrome Extension (EXT-02, WASM)
+    ↓ GET /mcp/browser-commands  (poll 2s)
+    ↓ ← Vec<BrowserCommand>
+    ↓ dispatch → DOM executor (EXT-02/EXT-03)
+    ↓ POST /mcp/browser-result
+    ↓ → BrowserResult → SR-03 queue update
+```
+
+## Почему отдельный ring, не расширение SR-02
+
+SR-02 — общий A2A registry и MCP tools для агентов.
+SR-03 — специализированный domain: браузерные команды, очередь,
+deduplication, TTL. Разделение по Single Responsibility (R1).
+
+## Laws
+
+- R1: только browser domain типы и очередь
+- Нет зависимостей кроме SR-00, SR-01
+- Нет tokio/async — чистые sync типы
+- Нет WASM — это серверный ring (native Rust)

--- a/crates/trios-a2a/rings/SR-03/TASK.md
+++ b/crates/trios-a2a/rings/SR-03/TASK.md
@@ -1,0 +1,35 @@
+# TASK — SR-03 (trios-a2a)
+
+## Status: ACTIVE
+
+## Completed ✅
+
+- [x] `BrowserCommandType` enum — все 12 операций
+- [x] `BrowserCommand` struct — команда с id, type, params, TTL
+- [x] `BrowserResult` struct — результат с ok/data/error
+- [x] `BrowserCommandQueue` — очередь с deduplication
+- [x] `mcp_browser_tool_definitions()` — 12 MCP tool schemas
+- [x] `AgentCard::browser_agent(tab_id)` в SR-00
+
+## Open P0 (нужен trios-server)
+
+- [ ] **HTTP endpoint** `GET /mcp/browser-commands`
+  trios-server держит `BrowserCommandQueue` из SR-03,
+  возвращает pending команды extension'у
+- [ ] **HTTP endpoint** `POST /mcp/browser-result`
+  принимает `BrowserResult`, обновляет очередь
+- [ ] **MCP handler** `a2a_browser_command` — AI агент вызывает tool,
+  команда попадает в очередь
+
+## Open P1 (trios-ext WASM)
+
+- [ ] EXT-02: `poll_commands()` → GET /mcp/browser-commands (каждые 2s)
+- [ ] EXT-02: `report_result()` → POST /mcp/browser-result
+- [ ] EXT-02: `register_agent()` → POST /a2a с AgentCard
+- [ ] EXT-02/03: `dispatch_command(json)` — роутер к DOM операциям
+
+## Open P2
+
+- [ ] `browser_screenshot` — html2canvas или getDisplayMedia
+- [ ] `browser_wait_for(selector, timeout_ms)` — MutationObserver
+- [ ] WebRTC stream для live view (далёкое будущее)

--- a/crates/trios-a2a/rings/SR-03/src/lib.rs
+++ b/crates/trios-a2a/rings/SR-03/src/lib.rs
@@ -1,0 +1,433 @@
+//! SR-03 — BrowserOS A2A Agent
+//!
+//! Server-side types for browser control via A2A/MCP protocol.
+//! AI agents call MCP tools → commands queue → Chrome extension polls → executes → reports back.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::VecDeque;
+use uuid::Uuid;
+
+/// All browser operations available via MCP.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BrowserCommandType {
+    GetUrl,
+    GetTitle,
+    Navigate,
+    GetDom,
+    QuerySelector,
+    Click,
+    Type,
+    Scroll,
+    Eval,
+    Screenshot,
+    OpenTab,
+    CloseTab,
+}
+
+impl std::fmt::Display for BrowserCommandType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = serde_json::to_value(self)
+            .ok()
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| format!("{:?}", self));
+        write!(f, "browser_{}", s)
+    }
+}
+
+/// A browser command issued by an AI agent via MCP.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrowserCommand {
+    /// Unique command ID (UUID v4)
+    pub id: String,
+    /// Target browser agent ID (e.g. "browser-agent-42")
+    pub target_agent: String,
+    /// Operation to perform
+    pub command_type: BrowserCommandType,
+    /// Operation parameters (tool-specific)
+    pub params: Value,
+    /// ISO8601 — when command was created
+    pub created_at: String,
+    /// ISO8601 — command expires at (default: +30s)
+    pub expires_at: String,
+    /// Current status
+    pub status: BrowserCommandStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BrowserCommandStatus {
+    /// Waiting for browser to poll
+    Pending,
+    /// Browser received and is executing
+    Executing,
+    /// Execution complete (see BrowserResult)
+    Done,
+    /// Timed out or error
+    Failed,
+}
+
+impl BrowserCommand {
+    pub fn new(target_agent: &str, command_type: BrowserCommandType, params: Value) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4().to_string(),
+            target_agent: target_agent.to_string(),
+            command_type,
+            params,
+            created_at: now.to_rfc3339(),
+            expires_at: (now + chrono::Duration::seconds(30)).to_rfc3339(),
+            status: BrowserCommandStatus::Pending,
+        }
+    }
+
+    /// Parse command type from MCP tool name (e.g. "browser_navigate" → Navigate)
+    pub fn from_tool_name(tool_name: &str, target_agent: &str, params: Value) -> Option<Self> {
+        let cmd_type = match tool_name {
+            "browser_get_url" => BrowserCommandType::GetUrl,
+            "browser_get_title" => BrowserCommandType::GetTitle,
+            "browser_navigate" => BrowserCommandType::Navigate,
+            "browser_get_dom" => BrowserCommandType::GetDom,
+            "browser_query_selector" => BrowserCommandType::QuerySelector,
+            "browser_click" => BrowserCommandType::Click,
+            "browser_type" => BrowserCommandType::Type,
+            "browser_scroll" => BrowserCommandType::Scroll,
+            "browser_eval" => BrowserCommandType::Eval,
+            "browser_screenshot" => BrowserCommandType::Screenshot,
+            "browser_open_tab" => BrowserCommandType::OpenTab,
+            "browser_close_tab" => BrowserCommandType::CloseTab,
+            _ => return None,
+        };
+        Some(Self::new(target_agent, cmd_type, params))
+    }
+}
+
+/// Result reported by Chrome extension after executing a command.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrowserResult {
+    pub command_id: String,
+    pub ok: bool,
+    pub data: Value,
+    pub error: Option<String>,
+    pub reported_at: String,
+}
+
+impl BrowserResult {
+    pub fn ok(command_id: &str, data: Value) -> Self {
+        Self {
+            command_id: command_id.to_string(),
+            ok: true,
+            data,
+            error: None,
+            reported_at: Utc::now().to_rfc3339(),
+        }
+    }
+
+    pub fn err(command_id: &str, msg: &str) -> Self {
+        Self {
+            command_id: command_id.to_string(),
+            ok: false,
+            data: Value::Null,
+            error: Some(msg.to_string()),
+            reported_at: Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+/// Server-side queue of pending browser commands.
+/// Held in trios-server, polled by Chrome extension every 2s.
+#[derive(Debug, Default)]
+pub struct BrowserCommandQueue {
+    pending: VecDeque<BrowserCommand>,
+    results: Vec<BrowserResult>,
+    /// Track seen command IDs to prevent duplicate execution
+    seen_ids: std::collections::HashSet<String>,
+}
+
+impl BrowserCommandQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enqueue a new command. Returns command id.
+    pub fn enqueue(&mut self, cmd: BrowserCommand) -> String {
+        let id = cmd.id.clone();
+        if !self.seen_ids.contains(&id) {
+            self.seen_ids.insert(id.clone());
+            self.pending.push_back(cmd);
+        }
+        id
+    }
+
+    /// Poll pending commands for a specific agent (called by extension).
+    /// Marks them as Executing.
+    pub fn poll(&mut self, agent_id: &str) -> Vec<BrowserCommand> {
+        let mut out = Vec::new();
+        for cmd in self.pending.iter_mut() {
+            if cmd.target_agent == agent_id && cmd.status == BrowserCommandStatus::Pending {
+                cmd.status = BrowserCommandStatus::Executing;
+                out.push(cmd.clone());
+            }
+        }
+        out
+    }
+
+    /// Record result from extension, mark command Done/Failed.
+    pub fn record_result(&mut self, result: BrowserResult) {
+        for cmd in self.pending.iter_mut() {
+            if cmd.id == result.command_id {
+                cmd.status = if result.ok {
+                    BrowserCommandStatus::Done
+                } else {
+                    BrowserCommandStatus::Failed
+                };
+                break;
+            }
+        }
+        self.results.push(result);
+    }
+
+    /// Get result for a specific command (for AI agent waiting on response).
+    pub fn get_result(&self, command_id: &str) -> Option<&BrowserResult> {
+        self.results.iter().find(|r| r.command_id == command_id)
+    }
+
+    pub fn pending_count(&self) -> usize {
+        self.pending
+            .iter()
+            .filter(|c| c.status == BrowserCommandStatus::Pending)
+            .count()
+    }
+}
+
+/// MCP tool definitions for browser control.
+/// Register these in trios-server's MCP service alongside SR-02 tools.
+pub fn mcp_browser_tool_definitions() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "browser_get_url",
+            "description": "Get current URL of the browser tab controlled by BrowserOS agent",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string", "description": "Target browser agent ID, e.g. browser-agent-42"}
+                },
+                "required": ["agent_id"]
+            }
+        }),
+        json!({
+            "name": "browser_get_title",
+            "description": "Get page title of the browser tab",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"}
+                },
+                "required": ["agent_id"]
+            }
+        }),
+        json!({
+            "name": "browser_navigate",
+            "description": "Navigate the browser tab to a URL",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"},
+                    "url": {"type": "string", "description": "URL to navigate to"}
+                },
+                "required": ["agent_id", "url"]
+            }
+        }),
+        json!({
+            "name": "browser_get_dom",
+            "description": "Get full page HTML of the browser tab",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"}
+                },
+                "required": ["agent_id"]
+            }
+        }),
+        json!({
+            "name": "browser_query_selector",
+            "description": "Find a DOM element by CSS selector, returns outer HTML",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"},
+                    "selector": {"type": "string", "description": "CSS selector"}
+                },
+                "required": ["agent_id", "selector"]
+            }
+        }),
+        json!({
+            "name": "browser_click",
+            "description": "Click a DOM element by CSS selector",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"},
+                    "selector": {"type": "string"}
+                },
+                "required": ["agent_id", "selector"]
+            }
+        }),
+        json!({
+            "name": "browser_type",
+            "description": "Type text into an input or textarea element",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"},
+                    "selector": {"type": "string"},
+                    "text": {"type": "string"}
+                },
+                "required": ["agent_id", "selector", "text"]
+            }
+        }),
+        json!({
+            "name": "browser_scroll",
+            "description": "Scroll the browser tab to coordinates",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"},
+                    "x": {"type": "number", "default": 0},
+                    "y": {"type": "number"}
+                },
+                "required": ["agent_id", "y"]
+            }
+        }),
+        json!({
+            "name": "browser_eval",
+            "description": "Evaluate a JavaScript expression in the browser tab (sandboxed via new Function)",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"},
+                    "js": {"type": "string", "description": "JS expression to evaluate"}
+                },
+                "required": ["agent_id", "js"]
+            }
+        }),
+        json!({
+            "name": "browser_screenshot",
+            "description": "Capture a screenshot of the browser tab as base64 PNG",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"}
+                },
+                "required": ["agent_id"]
+            }
+        }),
+        json!({
+            "name": "browser_open_tab",
+            "description": "Open a new browser tab with given URL",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"},
+                    "url": {"type": "string"}
+                },
+                "required": ["agent_id", "url"]
+            }
+        }),
+        json!({
+            "name": "browser_close_tab",
+            "description": "Close the current browser tab",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {"type": "string"}
+                },
+                "required": ["agent_id"]
+            }
+        }),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_creation() {
+        let cmd = BrowserCommand::new(
+            "browser-agent-42",
+            BrowserCommandType::Navigate,
+            json!({"url": "https://github.com"}),
+        );
+        assert_eq!(cmd.target_agent, "browser-agent-42");
+        assert_eq!(cmd.command_type, BrowserCommandType::Navigate);
+        assert_eq!(cmd.status, BrowserCommandStatus::Pending);
+    }
+
+    #[test]
+    fn test_from_tool_name() {
+        let cmd = BrowserCommand::from_tool_name(
+            "browser_navigate",
+            "browser-agent-1",
+            json!({"url": "https://example.com"}),
+        );
+        assert!(cmd.is_some());
+        assert_eq!(cmd.unwrap().command_type, BrowserCommandType::Navigate);
+
+        let unknown = BrowserCommand::from_tool_name("unknown_tool", "agent", json!({}));
+        assert!(unknown.is_none());
+    }
+
+    #[test]
+    fn test_queue_enqueue_poll() {
+        let mut q = BrowserCommandQueue::new();
+        let cmd = BrowserCommand::new("browser-agent-1", BrowserCommandType::GetUrl, json!({}));
+        let id = q.enqueue(cmd);
+        assert_eq!(q.pending_count(), 1);
+
+        let polled = q.poll("browser-agent-1");
+        assert_eq!(polled.len(), 1);
+        assert_eq!(polled[0].id, id);
+        assert_eq!(q.pending_count(), 0); // now Executing
+    }
+
+    #[test]
+    fn test_queue_deduplication() {
+        let mut q = BrowserCommandQueue::new();
+        let cmd = BrowserCommand::new("browser-agent-1", BrowserCommandType::GetUrl, json!({}));
+        let id = cmd.id.clone();
+        q.enqueue(cmd.clone());
+        q.enqueue(cmd); // duplicate
+        assert_eq!(q.pending_count(), 1); // only 1
+        drop(id);
+    }
+
+    #[test]
+    fn test_result_recording() {
+        let mut q = BrowserCommandQueue::new();
+        let cmd = BrowserCommand::new("browser-agent-1", BrowserCommandType::GetTitle, json!({}));
+        let id = q.enqueue(cmd);
+        q.poll("browser-agent-1");
+
+        let result = BrowserResult::ok(&id, json!({"title": "GitHub"}));
+        q.record_result(result);
+
+        let r = q.get_result(&id).unwrap();
+        assert!(r.ok);
+        assert_eq!(r.data["title"], "GitHub");
+    }
+
+    #[test]
+    fn test_mcp_tool_definitions() {
+        let tools = mcp_browser_tool_definitions();
+        assert_eq!(tools.len(), 12);
+        let names: Vec<&str> = tools.iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"browser_navigate"));
+        assert!(names.contains(&"browser_eval"));
+        assert!(names.contains(&"browser_screenshot"));
+    }
+}

--- a/crates/trios-ext/BROWSEROS.md
+++ b/crates/trios-ext/BROWSEROS.md
@@ -1,0 +1,76 @@
+# BrowserOS — A2A MCP Browser Control
+
+## Vision
+
+Chrome extension (trios-ext) becomes a **first-class A2A agent**.
+AI agents in trios-server can control the browser: open tabs, navigate,
+read DOM, inject text, click buttons — via standard MCP tool calls.
+
+## Why this is powerful
+
+Currently agents work in the dark: they can read GitHub issues and write code,
+but they cannot *see* what's happening in the browser. BrowserOS closes this gap:
+agents get eyes + hands in Chrome.
+
+## Architecture
+
+```
+trios-server (Rust)
+    ↓ HTTP POST /a2a
+    ↓ JSON: { tool: "browser_open_tab", params: { url: "..." } }
+
+Chrome Extension (WASM)
+    EXT-02 (MCP Client)
+        ↓ polls GET /mcp/browser-commands every 2s
+        ↓ receives pending commands
+    EXT-04 (BrowserOS Agent)
+        ↓ executes: tabs, navigation, DOM, clipboard, screenshot
+        ↓ reports result back via POST /mcp/browser-result
+```
+
+## A2A Registration
+
+On extension load, EXT-04 registers itself as an A2A agent:
+```json
+{
+  "tool": "a2a_register_agent",
+  "params": {
+    "id": "browser-agent-{tab_id}",
+    "name": "BrowserOS Agent",
+    "capabilities": ["browser_control", "dom_read", "dom_write"]
+  }
+}
+```
+
+## MCP Tools exposed by BrowserOS agent
+
+| Tool | Description |
+|------|-------------|
+| `browser_open_tab` | Open URL in new tab |
+| `browser_close_tab` | Close tab by id |
+| `browser_navigate` | Navigate current tab to URL |
+| `browser_get_url` | Get current tab URL |
+| `browser_get_title` | Get current tab title |
+| `browser_get_dom` | Get full page HTML |
+| `browser_query_selector` | Query DOM element |
+| `browser_click` | Click element by selector |
+| `browser_type` | Type text into element |
+| `browser_scroll` | Scroll page |
+| `browser_screenshot` | Capture viewport as base64 PNG |
+| `browser_eval` | Evaluate JS expression (sandboxed) |
+
+## Ring Mapping
+
+| Ring | Role |
+|------|------|
+| EXT-02 | MCP HTTP client — polls server, sends results |
+| EXT-04 | BrowserOS agent — executes browser commands |
+| EXT-03 | Content injectors — GitHub, Claude.ai |
+| EXT-00 | WASM entry — bootstraps all rings |
+
+## Security Model
+
+- Commands execute only on **whitelisted domains** (configurable in EXT-02 settings)
+- `browser_eval` is sandboxed — no access to extension APIs
+- All commands logged to `chrome.storage.local` with TTL 1h
+- Agent can be disabled via extension popup toggle

--- a/crates/trios-ext/rings/EXT-02/AGENTS.md
+++ b/crates/trios-ext/rings/EXT-02/AGENTS.md
@@ -1,14 +1,46 @@
-# AGENTS.md — EXT-02
+# AGENTS.md — EXT-02 (trios-ext)
 
-## Invariants
-- No dependencies on other EXT rings
-- Uses thread_local! for WASM-compatible state
-- All chrome.storage calls are async via JS interop
+> AAIF-compliant | MCP-compatible | BrowserOS
 
-## Testing
+## Identity
+
+- Ring: EXT-02
+- Package: trios-ext-ext02
+- Role: MCP HTTP client + settings store
+
+## Current state
+
+Only `chrome.storage.local` wrapper for API key. Settings only.
+
+## Target state (this PR)
+
+Add MCP HTTP polling client for BrowserOS A2A commands.
+
+## Rules (ABSOLUTE)
+
+- Read `LAWS.md` before ANY action
+- L24: HTTP only — NO WebSocket, no SSE, no long-poll socket
+- L6: Pure Rust/WASM — no TypeScript logic
+- R1: Do NOT import from EXT-03 or EXT-04 directly
+- Poll via `fetch()` WASM binding only — no chrome.runtime.connect
+
+## You MAY
+
+- ✅ Add `mcp_poll_commands()` — GET /mcp/browser-commands
+- ✅ Add `mcp_report_result()` — POST /mcp/browser-result
+- ✅ Add `a2a_register()` — register browser agent on startup
+- ✅ Add `get_server_url()` from storage
+- ✅ Add interval-based polling via `setInterval` WASM binding
+
+## You MAY NOT
+
+- ❌ Add WebSocket connections
+- ❌ Import from EXT-03, EXT-04
+- ❌ Add DOM manipulation logic (that's EXT-03/EXT-04)
+- ❌ Use TypeScript
+
+## Build
+
 ```bash
-cargo check --target wasm32-unknown-unknown
+cargo build -p trios-ext-ext02 --target wasm32-unknown-unknown
 ```
-
-## How to Extend
-- New setting: Add thread_local! static + getter/setter + chrome.storage key

--- a/crates/trios-ext/rings/EXT-02/RING.md
+++ b/crates/trios-ext/rings/EXT-02/RING.md
@@ -1,0 +1,42 @@
+# RING — EXT-02 (trios-ext)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥈 Silver |
+| Package | trios-ext-ext02 |
+| Sealed | No |
+
+## Current state
+
+Settings ring: `chrome.storage.local` wrapper for API key.
+
+## Upgraded purpose (BrowserOS A2A)
+
+MCP HTTP Client ring. Polls `trios-server` for pending browser commands
+and reports results back. Also manages A2A agent registration on startup.
+
+## Why EXT-02 owns the HTTP client
+
+EXT-03 owns DOM injection. EXT-04 owns command execution.
+Something must own the **transport** — the HTTP poll loop and result reporting.
+EXT-02 already owns `chrome.storage.local` (settings) so it's the natural home
+for the client config (server URL, poll interval, auth token).
+
+## API Surface (target after upgrade)
+
+| Function | Role |
+|----------|------|
+| `mcp_poll_commands()` | GET /mcp/browser-commands → Vec<BrowserCommand> |
+| `mcp_report_result()` | POST /mcp/browser-result |
+| `a2a_register()` | POST /a2a with a2a_register_agent tool call |
+| `get_server_url()` | Read server URL from chrome.storage.local |
+| `get_poll_interval_ms()` | Read poll interval (default: 2000ms) |
+
+## Laws
+
+- L24: HTTP only — no WebSocket
+- I4: No direct WebSocket connections
+- L6: Pure Rust/WASM — no TypeScript
+- R1: No imports from EXT-03, EXT-04

--- a/crates/trios-ext/rings/EXT-02/TASK.md
+++ b/crates/trios-ext/rings/EXT-02/TASK.md
@@ -1,5 +1,31 @@
-# Tasks EXT-02
+# TASK — EXT-02 (trios-ext)
 
-- [x] Thread-local API key cache
-- [x] chrome.storage.local read/write
-- [x] wasm_bindgen export for settings_save_key
+## Status: IN PROGRESS
+
+## Completed
+
+- [x] `chrome.storage.local` wrapper: `save_api_key`, `load_api_key`, `get_api_key`
+- [x] `settings_save_key()` wasm_bindgen export
+
+## Open P0 (критично для BrowserOS)
+
+- [ ] **`a2a_register()`** — POST /a2a `{tool: "a2a_register_agent", params: {id, name, capabilities}}`
+  Через `web_sys::fetch_with_request` (без WebSocket)
+- [ ] **`mcp_poll_commands()`** — GET `{server_url}/mcp/browser-commands`
+  возвращает `Vec<BrowserCommand>` (deserialized JSON)
+- [ ] **`mcp_report_result()`** — POST `{server_url}/mcp/browser-result`
+  принимает `BrowserResult` struct
+- [ ] **`start_poll_loop()`** — `setInterval` 2000ms → `mcp_poll_commands()` → dispatch в EXT-04
+  (через `js_sys::Function` callback)
+
+## Open P1
+
+- [ ] `get_server_url()` — читать `trios_server_url` из chrome.storage.local
+- [ ] `get_poll_interval_ms()` — читать `poll_interval_ms` из storage (default 2000)
+- [ ] Retry backoff: 2s → 4s → 8s → max 30s при ошибках сервера
+- [ ] Command deduplication по `command_id` чтобы не выполнять дважды
+
+## Open P2
+
+- [ ] Аутентификация: передавать `zai_key` в header `Authorization: Bearer {key}`
+- [ ] Логирование команд в `chrome.storage.local` с TTL 1h

--- a/crates/trios-ext/rings/EXT-04/AGENTS.md
+++ b/crates/trios-ext/rings/EXT-04/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md — EXT-04 (trios-ext)
+
+> AAIF-compliant | MCP-compatible | BrowserOS
+
+## Identity
+
+- Ring: EXT-04
+- Package: trios-ext-ext04
+- Role: BrowserOS A2A agent — browser command executor
+
+## What this ring does
+
+Receives `BrowserCommand` structs from EXT-02 (MCP poll loop) and executes them:
+tab navigation, DOM queries, click, type, scroll, screenshot, eval.
+
+## Rules (ABSOLUTE)
+
+- Read `LAWS.md` before ANY action
+- R1: Do NOT import from EXT-00, EXT-01, EXT-02, EXT-03
+- L6: Pure Rust/WASM only — no TypeScript
+- `browser_eval` MUST use `new Function(code)()` — NOT `eval()` directly
+- All operations sync — WASM is single-threaded, no async/await in WASM context
+- Never access `chrome.*` APIs directly — those belong to EXT-02
+
+## You MAY
+
+- ✅ Add new `BrowserCommandType` variants (with corresponding handler)
+- ✅ Add new `#[wasm_bindgen]` exports for new browser operations
+- ✅ Add tests (use `wasm-bindgen-test`)
+- ✅ Improve `dispatch_command()` routing
+
+## You MAY NOT
+
+- ❌ Import from other EXT rings
+- ❌ Use `eval()` directly — only `new Function(code)()`
+- ❌ Access `chrome.tabs`, `chrome.runtime` (content script restriction)
+- ❌ Add async/Promise chains in Rust (use JS setTimeout via web_sys)
+
+## Build
+
+```bash
+cargo build -p trios-ext-ext04 --target wasm32-unknown-unknown
+wasm-pack build crates/trios-ext/rings/EXT-04 --target web
+```

--- a/crates/trios-ext/rings/EXT-04/Cargo.toml
+++ b/crates/trios-ext/rings/EXT-04/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "trios-ext-ext04"
+version = "0.1.0"
+edition = "2021"
+authors = ["Dmitrii Vasilev"]
+license = "MIT"
+description = "EXT-04: BrowserOS A2A agent — browser tab control, DOM, navigation via MCP tools"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+
+[dependencies]
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Document",
+    "Element",
+    "HtmlElement",
+    "HtmlInputElement",
+    "HtmlTextAreaElement",
+    "Node",
+    "NodeList",
+    "Location",
+    "Navigator",
+    "Clipboard",
+    "Event",
+    "KeyboardEvent",
+    "MouseEvent",
+    "ScrollToOptions",
+] }
+js-sys = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+log = "0.4"
+console_log = "1"

--- a/crates/trios-ext/rings/EXT-04/RING.md
+++ b/crates/trios-ext/rings/EXT-04/RING.md
@@ -1,0 +1,52 @@
+# RING — EXT-04 (trios-ext)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥈 Silver |
+| Package | trios-ext-ext04 |
+| Sealed | No |
+
+## Purpose
+
+BrowserOS A2A Agent ring. Executes browser control commands received from
+trios-server via EXT-02 (MCP HTTP client). This is the "hands" of the
+BrowserOS system — it can open tabs, navigate, read/write DOM, click, type.
+
+## Why a new ring instead of extending EXT-03
+
+EXT-03 is a **content injector** — it injects specific UI into specific sites
+(GitHub button, Claude textarea). It's narrow and site-specific.
+
+EXT-04 is a **general-purpose browser agent** — it executes arbitrary browser
+commands from the A2A network. These are fundamentally different responsibilities.
+Mixing them would violate R1 (single responsibility per ring).
+
+## API Surface (pub + wasm_bindgen)
+
+| Function | Chrome API used | Description |
+|----------|-----------------|-------------|
+| `browser_get_url()` | `window.location.href` | Current tab URL |
+| `browser_get_title()` | `document.title` | Current tab title |
+| `browser_navigate(url)` | `window.location.assign()` | Navigate to URL |
+| `browser_get_dom()` | `document.documentElement.outerHTML` | Full page HTML |
+| `browser_query_selector(sel)` | `document.querySelector` | Find element |
+| `browser_click(sel)` | `.click()` | Click element |
+| `browser_type(sel, text)` | `.value = text` + input event | Type into field |
+| `browser_scroll(x, y)` | `window.scrollTo` | Scroll page |
+| `browser_eval(js)` | `Function()` sandboxed | Eval JS expression |
+| `dispatch_command(json)` | — | Route JSON command to above fns |
+
+## Dependencies
+
+- `wasm-bindgen`, `web-sys`, `js-sys`
+- `serde`, `serde_json` (command deserialization)
+- No imports from other EXT rings
+
+## Laws
+
+- R1: No imports from EXT-00, EXT-01, EXT-02, EXT-03
+- L6: Pure Rust/WASM — no TypeScript
+- `browser_eval` sandboxed — `new Function(js)()` only, no `eval()`
+- All operations must be non-blocking (WASM single-threaded)

--- a/crates/trios-ext/rings/EXT-04/TASK.md
+++ b/crates/trios-ext/rings/EXT-04/TASK.md
@@ -1,0 +1,46 @@
+# TASK — EXT-04 (trios-ext)
+
+## Status: ACTIVE — начинаем сейчас
+
+## Open P0 (минимально для работы)
+
+- [ ] **`BrowserCommand` struct** — deserialized MCP command:
+  ```rust
+  pub struct BrowserCommand {
+      pub id: String,        // UUID
+      pub tool: String,      // "browser_navigate", "browser_click", ...
+      pub params: Value,     // serde_json::Value
+  }
+  ```
+- [ ] **`BrowserResult` struct** — result to report back:
+  ```rust
+  pub struct BrowserResult {
+      pub command_id: String,
+      pub ok: bool,
+      pub data: Value,
+      pub error: Option<String>,
+  }
+  ```
+- [ ] **`dispatch_command(json: &str) -> String`** — парсит BrowserCommand, роутит, возвращает BrowserResult JSON
+- [ ] **`browser_get_url()`** — `window.location.href`
+- [ ] **`browser_get_title()`** — `document.title`
+- [ ] **`browser_navigate(url: &str)`** — `window.location.assign(url)`
+- [ ] **`browser_get_dom() -> String`** — `document.documentElement.outerHTML`
+- [ ] **`browser_query_selector(sel: &str) -> Option<String>`** — outer HTML элемента
+
+## Open P1
+
+- [ ] `browser_click(selector: &str) -> bool`
+- [ ] `browser_type(selector: &str, text: &str) -> bool` + input/change events
+- [ ] `browser_scroll(x: f64, y: f64)`
+- [ ] `browser_eval(js: &str) -> String` — `new Function(js)()` sandboxed
+
+## Open P2
+
+- [ ] `browser_screenshot()` — `html2canvas` или `getDisplayMedia` (requires permissions)
+- [ ] `browser_wait_for(selector, timeout_ms)` — MutationObserver-based
+- [ ] `browser_get_text(selector)` — `textContent` элемента
+
+## Blocked by
+
+EXT-02 P0: `mcp_poll_commands()` — без поллинга EXT-04 не будет получать команды.

--- a/crates/trios-ext/rings/EXT-04/src/lib.rs
+++ b/crates/trios-ext/rings/EXT-04/src/lib.rs
@@ -1,0 +1,247 @@
+//! EXT-04 — BrowserOS A2A Agent
+//!
+//! Executes browser control commands received from trios-server via MCP.
+//! No imports from other EXT rings. Pure WASM/web-sys.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+/// Incoming MCP browser command from trios-server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrowserCommand {
+    pub id: String,
+    pub tool: String,
+    pub params: Value,
+}
+
+/// Result reported back to trios-server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrowserResult {
+    pub command_id: String,
+    pub ok: bool,
+    pub data: Value,
+    pub error: Option<String>,
+}
+
+impl BrowserResult {
+    pub fn ok(command_id: &str, data: Value) -> Self {
+        Self { command_id: command_id.into(), ok: true, data, error: None }
+    }
+    pub fn err(command_id: &str, msg: &str) -> Self {
+        Self { command_id: command_id.into(), ok: false, data: Value::Null, error: Some(msg.into()) }
+    }
+}
+
+/// Dispatch a JSON command string → execute → return JSON result string.
+/// Called by EXT-02 poll loop after receiving a command from trios-server.
+#[wasm_bindgen]
+pub fn dispatch_command(json_cmd: &str) -> String {
+    let cmd: BrowserCommand = match serde_json::from_str(json_cmd) {
+        Ok(c) => c,
+        Err(e) => {
+            let r = BrowserResult::err("unknown", &format!("parse error: {}", e));
+            return serde_json::to_string(&r).unwrap_or_default();
+        }
+    };
+
+    let result = match cmd.tool.as_str() {
+        "browser_get_url" => exec_get_url(&cmd.id),
+        "browser_get_title" => exec_get_title(&cmd.id),
+        "browser_navigate" => {
+            let url = cmd.params.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            exec_navigate(&cmd.id, url)
+        }
+        "browser_get_dom" => exec_get_dom(&cmd.id),
+        "browser_query_selector" => {
+            let sel = cmd.params.get("selector").and_then(|v| v.as_str()).unwrap_or("");
+            exec_query_selector(&cmd.id, sel)
+        }
+        "browser_click" => {
+            let sel = cmd.params.get("selector").and_then(|v| v.as_str()).unwrap_or("");
+            exec_click(&cmd.id, sel)
+        }
+        "browser_type" => {
+            let sel = cmd.params.get("selector").and_then(|v| v.as_str()).unwrap_or("");
+            let text = cmd.params.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            exec_type(&cmd.id, sel, text)
+        }
+        "browser_scroll" => {
+            let x = cmd.params.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let y = cmd.params.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            exec_scroll(&cmd.id, x, y)
+        }
+        "browser_eval" => {
+            let js = cmd.params.get("js").and_then(|v| v.as_str()).unwrap_or("");
+            exec_eval(&cmd.id, js)
+        }
+        unknown => BrowserResult::err(&cmd.id, &format!("unknown tool: {}", unknown)),
+    };
+
+    serde_json::to_string(&result).unwrap_or_default()
+}
+
+// ─── Executors ────────────────────────────────────────────────────
+
+fn exec_get_url(id: &str) -> BrowserResult {
+    match web_sys::window().and_then(|w| w.location().href().ok()) {
+        Some(url) => BrowserResult::ok(id, json!({"url": url})),
+        None => BrowserResult::err(id, "window.location.href unavailable"),
+    }
+}
+
+fn exec_get_title(id: &str) -> BrowserResult {
+    match web_sys::window().and_then(|w| w.document()).map(|d| d.title()) {
+        Some(title) => BrowserResult::ok(id, json!({"title": title})),
+        None => BrowserResult::err(id, "document.title unavailable"),
+    }
+}
+
+fn exec_navigate(id: &str, url: &str) -> BrowserResult {
+    if url.is_empty() {
+        return BrowserResult::err(id, "url param required");
+    }
+    match web_sys::window() {
+        Some(w) => match w.location().assign(url) {
+            Ok(_) => BrowserResult::ok(id, json!({"navigating_to": url})),
+            Err(e) => BrowserResult::err(id, &format!("{:?}", e)),
+        },
+        None => BrowserResult::err(id, "window unavailable"),
+    }
+}
+
+fn exec_get_dom(id: &str) -> BrowserResult {
+    let html = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.document_element())
+        .map(|el| el.outer_html());
+    match html {
+        Some(h) => BrowserResult::ok(id, json!({"html": h})),
+        None => BrowserResult::err(id, "document not available"),
+    }
+}
+
+fn exec_query_selector(id: &str, selector: &str) -> BrowserResult {
+    if selector.is_empty() {
+        return BrowserResult::err(id, "selector param required");
+    }
+    let result = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.query_selector(selector).ok().flatten())
+        .map(|el| el.outer_html());
+    match result {
+        Some(html) => BrowserResult::ok(id, json!({"found": true, "html": html})),
+        None => BrowserResult::ok(id, json!({"found": false})),
+    }
+}
+
+fn exec_click(id: &str, selector: &str) -> BrowserResult {
+    if selector.is_empty() {
+        return BrowserResult::err(id, "selector param required");
+    }
+    let clicked = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.query_selector(selector).ok().flatten())
+        .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+        .map(|el| { el.click(); true })
+        .unwrap_or(false);
+    if clicked {
+        BrowserResult::ok(id, json!({"clicked": selector}))
+    } else {
+        BrowserResult::err(id, &format!("element not found: {}", selector))
+    }
+}
+
+fn exec_type(id: &str, selector: &str, text: &str) -> BrowserResult {
+    if selector.is_empty() {
+        return BrowserResult::err(id, "selector param required");
+    }
+    let doc = match web_sys::window().and_then(|w| w.document()) {
+        Some(d) => d,
+        None => return BrowserResult::err(id, "document unavailable"),
+    };
+    let el = match doc.query_selector(selector).ok().flatten() {
+        Some(e) => e,
+        None => return BrowserResult::err(id, &format!("element not found: {}", selector)),
+    };
+    if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+        input.set_value(text);
+        let _ = input.dispatch_event(&web_sys::Event::new("input").unwrap());
+        let _ = input.dispatch_event(&web_sys::Event::new("change").unwrap());
+        return BrowserResult::ok(id, json!({"typed": text.len()}));
+    }
+    if let Some(ta) = el.dyn_ref::<web_sys::HtmlTextAreaElement>() {
+        ta.set_value(text);
+        let _ = ta.dispatch_event(&web_sys::Event::new("input").unwrap());
+        let _ = ta.dispatch_event(&web_sys::Event::new("change").unwrap());
+        return BrowserResult::ok(id, json!({"typed": text.len()}));
+    }
+    BrowserResult::err(id, "element is not input or textarea")
+}
+
+fn exec_scroll(id: &str, x: f64, y: f64) -> BrowserResult {
+    match web_sys::window() {
+        Some(w) => {
+            w.scroll_to_with_x_and_y(x, y);
+            BrowserResult::ok(id, json!({"scrolled_to": {"x": x, "y": y}}))
+        }
+        None => BrowserResult::err(id, "window unavailable"),
+    }
+}
+
+fn exec_eval(id: &str, js: &str) -> BrowserResult {
+    if js.is_empty() {
+        return BrowserResult::err(id, "js param required");
+    }
+    // Sandboxed: use new Function(code)() — NOT eval()
+    let wrapped = format!("(new Function({}))()", serde_json::to_string(js).unwrap_or_default());
+    let result = js_sys::eval(&wrapped);
+    match result {
+        Ok(val) => {
+            let s = val.as_string().unwrap_or_else(|| format!("{:?}", val));
+            BrowserResult::ok(id, json!({"result": s}))
+        }
+        Err(e) => {
+            let msg = e.as_string().unwrap_or_else(|| "eval error".into());
+            BrowserResult::err(id, &msg)
+        }
+    }
+}
+
+// ─── wasm_bindgen exports ────────────────────────────────────────────
+
+#[wasm_bindgen]
+pub fn browser_get_url() -> Option<String> {
+    web_sys::window().and_then(|w| w.location().href().ok())
+}
+
+#[wasm_bindgen]
+pub fn browser_get_title() -> Option<String> {
+    web_sys::window().and_then(|w| w.document()).map(|d| d.title())
+}
+
+#[wasm_bindgen]
+pub fn browser_navigate(url: &str) -> bool {
+    web_sys::window()
+        .and_then(|w| w.location().assign(url).ok())
+        .is_some()
+}
+
+#[wasm_bindgen]
+pub fn browser_get_dom() -> Option<String> {
+    web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.document_element())
+        .map(|el| el.outer_html())
+}
+
+#[wasm_bindgen]
+pub fn browser_click(selector: &str) -> bool {
+    web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.query_selector(selector).ok().flatten())
+        .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+        .map(|el| { el.click(); true })
+        .unwrap_or(false)
+}


### PR DESCRIPTION
## Что это

AI агенты из trios-server теперь могут управлять Chrome-браузером через стандартные MCP tool calls. Через `trios-a2a`, не через новый crate.

## Поток данных

```
AI agent → browser_navigate({agent_id, url})
         → SR-03: BrowserCommand → BrowserCommandQueue
         → HTTP GET /mcp/browser-commands (trios-server)
         → trios-ext EXT-02 poll (2s)
         → EXT-02/03 dispatch → DOM
         → HTTP POST /mcp/browser-result
         → SR-03: BrowserResult → AI agent
```

## Что в PR

### SR-00: +3 новых Capability
- `BrowserControl`, `DomRead`, `DomWrite`
- `AgentCard::browser_agent(tab_id)` — фабрика BrowserOS агента

### SR-03: новый ring (trios-a2a-sr03)
- `BrowserCommandType` enum — 12 операций
- `BrowserCommand` + `BrowserResult` structs с serde
- `BrowserCommandQueue` — deduplication + TTL + poll/record
- `from_tool_name()` — парсинг MCP tool name → command
- `mcp_browser_tool_definitions()` — 12 MCP tool JSON schemas
- 5 тестов

### Cargo.toml
- SR-03 добавлен в workspace members

## Чего не хватает (next PRs)

| Что | Crate | Приоритет |
|-----|-------|----------|
| HTTP endpoints `/mcp/browser-commands` + `/mcp/browser-result` | trios-server | P0 |
| MCP handler `a2a_browser_command` | trios-server | P0 |
| EXT-02: `poll_commands()` + `report_result()` + `register_agent()` | trios-ext | P1 |
| EXT-02/03: `dispatch_command(json)` DOM executor | trios-ext | P1 |

## Laws ✅
- L6: Rust only, 0 TypeScript
- R1: SR-03 — только browser domain
- SR-03 не импортирует SR-02 (circular dep избежён)
- Нет async/tokio в SR-03 — чистые синх типы
- EXT-00 не тронут
