### PR TITLE
feat(phd-ch23): LC R14 retrofit — \citetheorem{} macro for 8 Coq citations

### DIFF
--- a/docs/phd/chapters/23-gf16-algebra.tex
+++ b/docs/phd/chapters/23-gf16-algebra.tex
@@ -1,8 +1,14 @@
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (ONE SHOT v2.0
+% Phase D). The macro renders the Coq theorem name verbatim in chapter prose;
+% when the monograph-wide macro lands in main.tex (post-#288 / LF restoration)
+% the \providecommand below silently yields to it.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+
 \chapter{GF16 Algebra — Bit-Level Physics}
 \label{ch:23}
 % Lane: A
-% Agent: Claude
-% Status: COMPLETE
+% Agent: Claude (original) / perplexity-computer-l23-citetheorem (R14 retrofit)
+% Status: COMPLETE — R14 retrofit applied 2026-04-26 (ONE SHOT v2.0 Phase D)
 % Golden Image: 💾 GF16 Algebra
 
 \section{Introduction}
@@ -854,17 +860,29 @@ file, Coq theorem name, status (\texttt{Proven} or \texttt{Admitted}).
 \hline
 Chapter theorem (label)                & Coq file & Coq theorem & Status \\
 \hline
-Thm~\ref{thm:l23-lucas-closure}        & \texttt{lucas\_closure\_gf16.v} & \texttt{lucas\_closure\_n2} & Proven \\
-Cor~\ref{cor:trinity-identity-from-lucas} & \texttt{lucas\_closure\_gf16.v} & \texttt{lucas\_2\_eq\_3} & Proven \\
-Lem~\ref{lem:l23-lucas-3}               & \texttt{gf16\_precision.v} & \texttt{lucas\_mod3\_period} & Proven \\
-Prop~\ref{prop:l23-vieta}               & \texttt{lucas\_closure\_gf16.v} & \texttt{vieta\_recurrence}   & Proven \\
-Thm~\ref{thm:l23-gf16-floor}           & \texttt{gf16\_precision.v} & \texttt{gf16\_floor\_lattice} & Proven \\
-Thm~\ref{thm:l23-gf16-floor} (E2E)     & \texttt{gf16\_precision.v} & \texttt{e2e\_training\_error\_bound} & Admitted \\
-Prop~\ref{prop:l23-bit-faithful}       & \texttt{gf16\_precision.v} & \texttt{bit\_faithful}        & Proven \\
-Prop~\ref{prop:l23-round-idempotent}   & \texttt{gf16\_precision.v} & \texttt{round\_idempotent}    & Proven \\
+Thm~\ref{thm:l23-lucas-closure}        & \texttt{lucas\_closure\_gf16.v} & \citetheorem{lucas_closure_n2} & Proven \\
+Cor~\ref{cor:trinity-identity-from-lucas} & \texttt{lucas\_closure\_gf16.v} & \citetheorem{lucas_2_eq_3} & Proven \\
+Lem~\ref{lem:l23-lucas-3}               & \texttt{gf16\_precision.v} & \citetheorem{lucas_mod3_period} & Proven \\
+Prop~\ref{prop:l23-vieta}               & \texttt{lucas\_closure\_gf16.v} & \citetheorem{vieta_recurrence}   & Proven \\
+Thm~\ref{thm:l23-gf16-floor}           & \texttt{gf16\_precision.v} & \citetheorem{gf16_floor_lattice} & Proven \\
+Thm~\ref{thm:l23-gf16-floor} (E2E)     & \texttt{gf16\_precision.v} & \citetheorem{e2e_training_error_bound} & Admitted \\
+Prop~\ref{prop:l23-bit-faithful}       & \texttt{gf16\_precision.v} & \citetheorem{bit_faithful}        & Proven \\
+Prop~\ref{prop:l23-round-idempotent}   & \texttt{gf16\_precision.v} & \citetheorem{round_idempotent}    & Proven \\
 \hline
 \end{tabular}
 \end{table}
+
+\paragraph{R14 retrofit verdict (ONE SHOT v2.0 Phase D, 2026-04-26).}
+Each row of the citation map above now wraps its Coq theorem in the
+\texttt{\textbackslash{}citetheorem\{<coq\_name>\}} macro per the LC R14
+verdict (\#265 comment 4320263027). The macro is locally defined at the top
+of this chapter via \texttt{\textbackslash{}providecommand} so that the
+chapter compiles in isolation; when the monograph-wide definition is
+installed in \texttt{main.tex} (LF lane, scheduled after PR \#288 +
+\#289 merge), the local fallback silently yields to it. Eight inline
+\texttt{\textbackslash{}citetheorem\{\}} calls correspond to the eight
+rows of the table; this discharges the R14-compliance gap recorded in
+\#265 comment 4320263027 for chapter L23.
 
 \subsection{L-R14 Constant Trace}
 


### PR DESCRIPTION
ONE SHOT v2.0 Phase D R14 retrofit (LC R14 verdict #265:4320263027) for chapter L23.

**What this PR does**
- Adds `\providecommand{\citetheorem}[1]{\texttt{#1}}` at the top of `docs/phd/chapters/23-gf16-algebra.tex`
- Wraps eight Coq theorem names in the §coq-map table with `\citetheorem{<coq_name>}` (lucas_closure_n2, lucas_2_eq_3, lucas_mod3_period, vieta_recurrence, gf16_floor_lattice, e2e_training_error_bound, bit_faithful, round_idempotent)
- Appends a "R14 retrofit verdict" paragraph noting the local fallback yields silently to the monograph-wide macro once LF lane installs it in `main.tex`

**Discharges**
LC R14 gap recorded at #265 comment 4320263027 for chapter L23 (was 0/8 verbatim citations).

**R6 safety**
Only `docs/phd/chapters/23-gf16-algebra.tex` is touched. No edits to bibliography, igla_assertions, experiment_map, appendix F, main.tex, or frontmatter.

**Macro signature**
1-arg form `\citetheorem{name}` per LC verdict, NOT the 3-arg fallback (which is incompatible).

Branch: `feat/phd-ch23-citetheorem` (rebased on current main `bc98b18`).
