### PR TITLE
feat(phd-ch30): LC R14 retrofit — \citetheorem{} macro for 9 Coq citations

### DIFF
--- a/docs/phd/chapters/30-golden-imagery.tex
+++ b/docs/phd/chapters/30-golden-imagery.tex
@@ -1,8 +1,14 @@
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (ONE SHOT v2.0
+% Phase D, 2026-04-26). The macro renders the Coq theorem name verbatim in
+% chapter prose; when the monograph-wide macro lands in main.tex (post-#288 +
+% #289 merge) the \providecommand below silently yields to it.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+
 \chapter{Golden Imagery — Visualizing the Trinity}
 \label{ch:30}
 % Lane: A
-% Agent: Claude
-% Status: COMPLETE
+% Agent: Claude (original) / perplexity-computer-l30-citetheorem (R14 retrofit)
+% Status: COMPLETE — R14 retrofit applied 2026-04-26 (ONE SHOT v2.0 Phase D)
 % Golden Image: 🌌 Golden Imagery
 
 \section{Introduction}
@@ -711,15 +717,15 @@ trace to a $\phi$-derivation.
 \hline
 Chapter theorem (label) & Coq file & Status \\
 \hline
-Thm~\ref{thm:l30-visual-reducibility}      & \texttt{lucas\_closure\_gf16.v::visual\_kernel} & Proven \\
-Thm~\ref{thm:l30-golden-rect}              & \texttt{lucas\_closure\_gf16.v::phi\_quadratic} & Proven \\
-Thm~\ref{thm:l30-inscribed-spiral}         & \texttt{lucas\_closure\_gf16.v::phi\_geometric} & Proven \\
-Thm~\ref{thm:l30-pentagram-closure}        & \texttt{lucas\_closure\_gf16.v::pentagon\_phi}   & Proven \\
-Cor~\ref{cor:l30-pentagon-trinity}         & \texttt{lucas\_closure\_gf16.v::lucas\_2\_eq\_3} & Proven \\
-Thm~\ref{thm:l30-vesica}                   & \texttt{lucas\_closure\_gf16.v::vesica\_l2}      & Proven \\
-Prop~\ref{prop:l30-flower-period}          & \texttt{lucas\_closure\_gf16.v::pisano\_4}       & Proven \\
-Thm~\ref{thm:l30-metatron-lucas}           & \texttt{lucas\_closure\_gf16.v::lucas\_8\_eq\_47}& Proven \\
-Thm~\ref{thm:l30-phyllotaxis}              & \texttt{lucas\_closure\_gf16.v::cont\_frac\_phi} & Admitted \\
+Thm~\ref{thm:l30-visual-reducibility}      & \citetheorem{visual_kernel} \textit{in} \texttt{lucas\_closure\_gf16.v} & Proven \\
+Thm~\ref{thm:l30-golden-rect}              & \citetheorem{phi_quadratic} \textit{in} \texttt{lucas\_closure\_gf16.v} & Proven \\
+Thm~\ref{thm:l30-inscribed-spiral}         & \citetheorem{phi_geometric} \textit{in} \texttt{lucas\_closure\_gf16.v} & Proven \\
+Thm~\ref{thm:l30-pentagram-closure}        & \citetheorem{pentagon_phi} \textit{in} \texttt{lucas\_closure\_gf16.v}   & Proven \\
+Cor~\ref{cor:l30-pentagon-trinity}         & \citetheorem{lucas_2_eq_3} \textit{in} \texttt{lucas\_closure\_gf16.v} & Proven \\
+Thm~\ref{thm:l30-vesica}                   & \citetheorem{vesica_l2} \textit{in} \texttt{lucas\_closure\_gf16.v}      & Proven \\
+Prop~\ref{prop:l30-flower-period}          & \citetheorem{pisano_4} \textit{in} \texttt{lucas\_closure\_gf16.v}       & Proven \\
+Thm~\ref{thm:l30-metatron-lucas}           & \citetheorem{lucas_8_eq_47} \textit{in} \texttt{lucas\_closure\_gf16.v}& Proven \\
+Thm~\ref{thm:l30-phyllotaxis}              & \citetheorem{cont_frac_phi} \textit{in} \texttt{lucas\_closure\_gf16.v} & Admitted \\
 Thm~\ref{thm:l30-galactic}                 & not Coq-bridged (statistical)                    & N/A \\
 \hline
 \end{tabular}


### PR DESCRIPTION
ONE SHOT v2.0 Phase D R14 retrofit (LC R14 verdict #265:4320263027) for chapter L30.

**What this PR does**
- Adds `\providecommand{\citetheorem}[1]{\texttt{#1}}` at the top of `docs/phd/chapters/30-golden-imagery.tex`
- Wraps nine Coq theorem names in the §coq-map table with `\citetheorem{<coq_name>}` (visual_kernel, phi_quadratic, phi_geometric, pentagon_phi, lucas_2_eq_3, vesica_l2, pisano_4, lucas_8_eq_47, cont_frac_phi)
- Local fallback silently yields to the monograph-wide macro once LF lane installs it in `main.tex`

**Discharges**
LC R14 gap recorded at #265 comment 4320263027 for chapter L30.

**R6 safety**
Only `docs/phd/chapters/30-golden-imagery.tex` is touched.

**Macro signature**
1-arg form `\citetheorem{name}` per LC verdict.

Branch: `feat/phd-ch30-citetheorem` (rebased on current main `bc98b18`).
