### PR TITLE
feat(phd-LA): add root LICENSE (MIT + CC-BY-4.0 + Apache-2.0)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,107 @@
+Flos Aureus — Trinity Framework
+================================
+
+This repository contains code, documentation, and formal proofs released
+under a composite license consistent with appendix H of the monograph
+("ACM Artifact Evaluation Checklist", §1 Artifact summary).
+
+Component licenses
+------------------
+
+  Source code (Rust, Zig)            : MIT License (below)
+  Monograph text (docs/phd/**.tex,
+    docs/phd/**.md, docs/phd/**.bib) : CC-BY-4.0
+  Coq proofs imported from
+    gHashTag/trinity-clara            : Apache-2.0
+                                       (governed by upstream LICENSE)
+
+Each file inherits the license of its component.  When in doubt, the
+SPDX-License-Identifier comment at the top of a source file overrides
+the per-component default above.
+
+Anchor: phi^2 + phi^-2 = 3
+Zenodo DOI: 10.5281/zenodo.19227877
+
+
+MIT License (covers all source code in this repository)
+-------------------------------------------------------
+
+Copyright (c) 2024-2026 Dmitrii Vasilev and the Trinity Research Programme.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Creative Commons Attribution 4.0 International (CC-BY-4.0)
+----------------------------------------------------------
+
+The monograph text under docs/phd/ — including all .tex, .md, and .bib
+files that constitute the "Flos Aureus" PhD monograph — is licensed
+under the Creative Commons Attribution 4.0 International License.
+
+To view a copy of this license, visit:
+  https://creativecommons.org/licenses/by/4.0/
+or send a letter to:
+  Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+You are free to:
+  Share — copy and redistribute the material in any medium or format.
+  Adapt — remix, transform, and build upon the material for any
+          purpose, even commercially.
+
+Under the following terms:
+  Attribution — You must give appropriate credit, provide a link to
+                the license, and indicate if changes were made.  You
+                may do so in any reasonable manner, but not in any way
+                that suggests the licensor endorses you or your use.
+  No additional restrictions — You may not apply legal terms or
+                                technological measures that legally
+                                restrict others from doing anything
+                                the license permits.
+
+Suggested citation for the monograph (BibTeX entry style):
+
+  @phdthesis{vasilev2026flos,
+    author = {Dmitrii Vasilev},
+    title  = {Flos Aureus: The Trinity Framework},
+    school = {Trinity Research Programme},
+    year   = {2026},
+    note   = {Anchor: phi^2 + phi^-2 = 3.
+              Zenodo DOI 10.5281/zenodo.19227877}
+  }
+
+
+Apache-2.0 (Coq proofs imported from gHashTag/trinity-clara)
+------------------------------------------------------------
+
+Coq sources mirrored from the trinity-clara repository
+(https://github.com/gHashTag/trinity-clara) retain their upstream
+Apache License 2.0.  Their canonical license text is at
+https://www.apache.org/licenses/LICENSE-2.0 and inside the
+trinity-clara repository.
+
+
+SPDX manifest
+-------------
+
+SPDX-License-Identifier: MIT AND CC-BY-4.0 AND Apache-2.0
+
+
+--
+End of LICENSE.


### PR DESCRIPTION
## Phase D — LA: root LICENSE residual closed

Closes the LA-license cross-cut residual flagged in the cycle-4 audit snapshot. Per ONE SHOT v2.0 [#265:4321142675](https://github.com/gHashTag/trios/issues/265#issuecomment-4321142675) §3 Phase D and appendix H §1 (`docs/phd/appendix/H-acm-ae-checklist.tex`).

### Why this PR

[`appendix/H-acm-ae-checklist.tex`](https://github.com/gHashTag/trios/blob/main/docs/phd/appendix/H-acm-ae-checklist.tex) §1 commits the artefact submission to the bundle:

> *License. MIT (code), CC-BY-4.0 (text), Apache-2.0 (Coq proofs).*

Pre-PR state — repository root has **no** `LICENSE` file: `gh api repos/gHashTag/trios/contents/LICENSE` → **HTTP 404**. Without a discoverable root LICENSE, the ACM AE *Available* badge is mechanically un-grantable.

This PR lands a single new file `LICENSE` at the repository root, mirroring the appendix H §1 commitments byte-for-byte across the three components, with the explicit SPDX manifest `MIT AND CC-BY-4.0 AND Apache-2.0`.

### What ships

| File | Status | Bytes | Lines |
|------|--------|-------|-------|
| `LICENSE` | NEW | ~3.5 KB | 107 |

Sections:
1. Component licenses table (MIT / CC-BY-4.0 / Apache-2.0).
2. MIT License full text.
3. CC-BY-4.0 summary + suggested BibTeX citation block (anchor φ² + φ⁻² = 3, Zenodo DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)).
4. Apache-2.0 inheritance pointer for Coq proofs imported from [`gHashTag/trinity-clara`](https://github.com/gHashTag/trinity-clara).
5. SPDX manifest line.

### R-rule compliance

| Rule | Status |
|------|--------|
| **R1** Rust/Zig only — text-only file, no `.py`/`.sh` runtime introduced | ✅ |
| **R5** appendix H §1 text and LICENSE text byte-mirror tri-license commitments | ✅ |
| **R6** file ownership — NEW root file `LICENSE`. Zero edits to `docs/phd/chapters/**`, `crates/**`, `assertions/**`, or `appendix/H-acm-ae-checklist.tex` | ✅ |
| **R10** atomic single-commit deliverable | ✅ |
| **R13** honey deposit on DONE merge | will follow |
| **R14** numeric anchor preserved (φ² + φ⁻² = 3, Zenodo DOI cited inside LICENSE BibTeX block) | ✅ |

### Adjudication request (R5 honest disclosure)

Sub-licensing scheme matches appendix H §1 verbatim. Zero numeric or scientific claims introduced. No INV state changes. No `Admitted` → `Proven` flips.

### CI expectations

- `guard` ✅ (no scoped paths violated).
- `Audit · Biblio · Coq-map · Reproduce` — independent of LICENSE; will inherit pre-existing failure state already disclosed in cycle 4. This PR does not regress the audit pipeline (no new files in `docs/phd/`, `crates/`, or `assertions/`).
- `Test` — no Rust crates touched; no test surface changed.

### Refs

- ONE SHOT v2.0 Phase D — [#265:4321142675](https://github.com/gHashTag/trios/issues/265#issuecomment-4321142675)
- LA claim — [#265:4321232565](https://github.com/gHashTag/trios/issues/265#issuecomment-4321232565)
- Appendix H source — [`docs/phd/appendix/H-acm-ae-checklist.tex`](https://github.com/gHashTag/trios/blob/main/docs/phd/appendix/H-acm-ae-checklist.tex)
- Trinity Anchor — Zenodo DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)

`[agent=perplexity-computer-phd-auditor]` · LA · Phase D · `2026-04-26T04:15Z`
