### PR TITLE
fix(phd-LT): unblock Compile · tectonic — rename admittedbox env to fix \admittedbox macro collision

### DIFF
--- a/docs/phd/main.tex
+++ b/docs/phd/main.tex
@@ -78,7 +78,14 @@
 % Renders a red-bordered box around the text. Use whenever a theorem's Coq
 % counterpart in trinity-clara/proofs/igla/*.v is still Admitted; never use
 % to mask Admitted as Proven.
-\newtcolorbox{admittedbox}[1][]{
+% R5-honest visual marker. The tcolorbox environment is named
+% `admittedboxenv` so the convenience macro `\admittedbox{<text>}`
+% below can coexist with it (prior revisions collided: tcolorbox auto-
+% created a same-named token on \newtcolorbox{admittedbox}, which then
+% clashed with the subsequent \newcommand{\admittedbox}). All chapter
+% callsites use the macro form `\admittedbox{...}` only; the renamed
+% environment is an internal implementation detail.
+\newtcolorbox{admittedboxenv}[1][]{
   colback=red!4!white,
   colframe=red!60!black,
   boxrule=0.6pt,
@@ -88,7 +95,7 @@
   title={\bfseries Admitted (Coq status: not Proven \textemdash{} R5)},
   #1
 }
-\newcommand{\admittedbox}[1]{\begin{admittedbox}#1\end{admittedbox}}
+\newcommand{\admittedbox}[1]{\begin{admittedboxenv}#1\end{admittedboxenv}}
 
 % Falsification box (R7) — used by empirical chapters.
 \newtcolorbox{falsificationbox}[1][]{


### PR DESCRIPTION
## LT — `\admittedbox` macro/env collision fix in `main.tex`

Closes the pre-existing tectonic blocker that has been keeping the `Compile · tectonic` GitHub Action in `skipping` state on every chapter PR.

**Lane:** LT (`phd-monograph-auditor` v1.0). **Skill stack:** `trinity-grandmaster` v1.0 → `phd-monograph-auditor` v1.0.
**Anchor:** `φ² + φ⁻² = 3` · Zenodo DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877).
**Claim:** [#265#issuecomment-4321863948](https://github.com/gHashTag/trios/issues/265#issuecomment-4321863948).

### Defect

`docs/phd/main.tex` lines 81-91 declared:

```latex
\newtcolorbox{admittedbox}[1][]{ ... }                                              % auto-creates \admittedbox
\newcommand{\admittedbox}[1]{\begin{admittedbox}#1\end{admittedbox}}                % FATAL: redeclares
```

`\newtcolorbox{admittedbox}` automatically defines the macro `\admittedbox` as the environment opener; the subsequent `\newcommand{\admittedbox}` is therefore a redefinition and tectonic halts at line 91 with:

```
error: main.tex:91: LaTeX Error: Command \admittedbox already defined.
error: halted on potentially-recoverable error as specified
```

### Verification (R5 honest)

| Test | Result |
|---|---|
| `tectonic + bibtex` on `main` (`b7ec15f`) without fix | ❌ halts at `main.tex:91` (LaTeX `\admittedbox already defined`) |
| `tectonic + bibtex` on `main` (`b7ec15f`) **with fix** | ✅ proceeds past line 91; halts later at `chapters/00-monad.tex:56` `Missing $ inserted` (separate downstream L0 defect — out of this lane's scope) |
| `git grep "\\\\admittedbox"` across `docs/phd/` | 33 callsites, all of the form `\admittedbox{...}` (macro form). Zero `\begin{admittedbox}` outside the very `\newcommand` we are rewriting. → no chapter file needs editing (R6 holds). |

The fix is therefore **necessary** (without it tectonic halts) and **sufficient** (with it tectonic proceeds past line 91). The downstream L0 chapter defect at `00-monad.tex:56` is a separate ticket; **not** introduced by this PR — it was simply masked by the earlier hard halt.

### Fix (six lines, single file)

```diff
- \newtcolorbox{admittedbox}[1][]{ ... }
- \newcommand{\admittedbox}[1]{\begin{admittedbox}#1\end{admittedbox}}
+ \newtcolorbox{admittedboxenv}[1][]{ ... }
+ \newcommand{\admittedbox}[1]{\begin{admittedboxenv}#1\end{admittedboxenv}}
```

Plus a six-line inline comment documenting why the env was renamed (so the next agent doesn't re-introduce the collision).

The visual rendering of `\admittedbox{...}` is **byte-identical** before and after — same red-bordered tcolorbox, same R5-honest title `Admitted (Coq status: not Proven — R5)`. The renamed environment `admittedboxenv` is an internal implementation detail.

### What this PR explicitly does NOT do (R5/R6)

- ❌ **Zero** edits outside `docs/phd/main.tex`. No `chapters/*.tex`, no `appendix/*.tex`, no `frontmatter/*.tex`, no `bibliography.bib`, no `assertions/*.json`, no `*.v`, no `Cargo.toml`.
- ❌ **No** `Admitted → Proven` flips. The visual marker still loudly says `Admitted (Coq status: not Proven — R5)`.
- ❌ **No** chapter-level changes — every existing `\admittedbox{<text>}` callsite continues to work unchanged.
- ❌ **No** fix to the `chapters/00-monad.tex:56` `Missing $ inserted` downstream error — that is L0 lane-owner work, separate ticket recommended.

### R-rule compliance

| Rule | Compliance |
|---|---|
| **R1** Rust/Zig only | ✅ no `.py`/`.sh` introduced |
| **R5** honest Admitted | ✅ no status flips; visual rendering identical |
| **R6** lane discipline | ✅ single file, single concern, no other lane touched |
| **R10** atomic commits | ✅ one commit, one logical unit |

### Impact (once merged)

- `Compile · tectonic` job stops `skipping` on all PRs and starts producing real verdicts.
- `tools/page_gate` regains visibility into the actual page count of `main.pdf` produced by tectonic.
- Subsequent latent LaTeX errors (the `Missing $ inserted` at `00-monad.tex:56` and likely a few more downstream) become **visible** to chapter authors instead of hidden behind an opaque skip — chapters can now be debugged individually.
- LT lane flips from "blocked by latent defect" to "tracked, with downstream chain visible" on the next auditor cycle.

### Atomic commit (R10)

```
1f6d6ae fix(phd-LT): rename admittedbox env to admittedboxenv to end macro/env collision
```

### References

- ONE SHOT [trios#265](https://github.com/gHashTag/trios/issues/265)
- Throne [trios#264](https://github.com/gHashTag/trios/issues/264)
- v1.3 readiness audit ([#265#issuecomment-4320354889](https://github.com/gHashTag/trios/issues/265#issuecomment-4320354889)) §6 LT
- Sibling LF/LC/LP/LB PRs already MERGEABLE: #289 LF · #288 LC · #290 LP · #294 LB · #312 App.C/D
- Sibling Phase-A merges already on `main` (b7ec15f): #292/#295/#296/#297/#298/#300/#302/#304/#306/#307

— `perplexity-computer-phd-auditor` v1.0 + `trinity-grandmaster` v1.0 · `φ² + φ⁻² = 3`
