### PR TITLE
fix(phd-appendix-B): R5 honesty — Ch.8/Ch.18 Corroborated → Open

### DIFF
--- a/docs/phd/appendix/B-falsification.tex
+++ b/docs/phd/appendix/B-falsification.tex
@@ -31,10 +31,10 @@ table below collects those statements across the empirical chapters
 \bottomrule
 \endfoot
 
-8  & E$_8$ resonance ratio \(M_2/M_1 = \varphi\) in CoBr$_2$. & Mass ratio outside \([\varphi - 0.05,\ \varphi + 0.05]\) at \(T=25\) mK. & Corroborated (Coldea \emph{et al.}, 2010). & 2010 \\
+8  & E$_8$ resonance ratio \(M_2/M_1 = \varphi\) in CoBr$_2$. & Mass ratio outside \([\varphi - 0.05,\ \varphi + 0.05]\) at \(T=25\) mK. & Open (chapter body pending; Coldea \emph{et al.}, 2010 cited but not yet integrated). & --- \\
 9  & Icosahedral diffraction peaks scale by \(\varphi\). & Peak ratio outside \([\varphi - 0.02,\ \varphi + 0.02]\). & Corroborated (Shechtman \emph{et al.}, 1984). & 1984 \\
 17 & VSA capacity \(O(d/\log d)\) for \(d \geq 256\). & Capacity drops below \(0.8\,d/\log d\) at \(d=256\). & Corroborated (this work, Ch.~25). & 2026 \\
-18 & 1.58-bit BitNet preserves the \(\varphi\)-band when \(\mathrm{lr}\in[0.002, 0.007]\). & BPB \(>1.50\) at champion lr. & Corroborated (this work, Ch.~24). & 2026 \\
+18 & 1.58-bit BitNet preserves the \(\varphi\)-band when \(\mathrm{lr}\in[0.002, 0.007]\). & BPB \(>1.50\) at champion lr. & Open (chapter body pending; cross-reference Ch.~24 results). & --- \\
 20 & IGLA RACE search achieves BPB \(<1.50\) on three independent seeds. & BPB \(\geq 1.50\) on any seed in \(\{17, 42, 1729\}\). & Corroborated (this work, Ch.~24). & 2026 \\
 21 & JEPA-MSE proxy is unsafe; \verb|validate_bpb| must hard-fail at BPB \(\approx 0.014\). & A trial reports BPB \(\approx 0.014\) without \texttt{Err} from \verb|validate_bpb|. & Corroborated (J-001/J-002 audit). & 2026 \\
 22 & NCA entropy in the certified band \([\varphi, \varphi^{2}]\). & Steady-state entropy outside \([\varphi-0.05, \varphi^{2}+0.05]\). & Partially corroborated (Ch.~22). & 2026 \\


### PR DESCRIPTION
# R5 honesty fix — Appendix B falsification record

## What

Two rows in `docs/phd/appendix/B-falsification.tex` claimed `Corroborated` while their corresponding chapter bodies are still 3-line stubs in `main`:

- **Ch. 8** — `08-golden-crystal.tex` (3 lines, no §Falsification)
- **Ch. 18** — `18-torus-geometry.tex` (3 lines, no §Falsification)

Per **R5** (honesty rule: never re-label `Admitted` as `Proven`, by extension never claim `Corroborated` for an unwritten claim), both rows are flipped to `Open`.

## Verification

```bash
$ for n in 08 18; do
    f=$(ls docs/phd/chapters/${n}-*.tex | head -1)
    echo "$n  lines=$(wc -l < $f)  has_falsify=$(grep -c 'section{Falsification' $f || echo 0)"
  done
08  lines=3  has_falsify=0
18  lines=3  has_falsify=0
```

Other empirical chapters (9, 17, 20, 21, 22, 29) now have proper `\section{Falsification Criterion}` after Wave 2/3 merges and remain `Corroborated`/`Partially corroborated` legitimately.

## R-rules touched

- **R5** — pass: status now matches reality.
- **R7** — pass: appendix B still tracks every empirical chapter.
- **R3** — unaffected: appendix B itself is not a chapter under R3 line-floor.

## Lane

- **L?** cross-cutting auditor lane (LP-fix sub-task), filed by `computer-queen`.

Issue: gHashTag/trios#265
