### PR TITLE
fix(trios-ext): use PNG icons in manifest (Chrome MV3 doesn't support…

### DIFF
--- a/crates/trios-ext/extension/manifest.json
+++ b/crates/trios-ext/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Trinity Agent Bridge",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Trinity Agent Bridge — WASM sidepanel + MCP HTTP client",
   "permissions": [
     "sidePanel",
@@ -19,15 +19,15 @@
   "action": {
     "default_title": "Trinity Agent Bridge",
     "default_icon": {
-      "16": "icons/icon.svg",
-      "48": "icons/icon.svg",
-      "128": "icons/icon.svg"
+      "16": "icons/icon-16.png",
+      "48": "icons/icon-48.png",
+      "128": "icons/icon-128.png"
     }
   },
   "icons": {
-    "16": "icons/icon.svg",
-    "48": "icons/icon.svg",
-    "128": "icons/icon.svg"
+    "16": "icons/icon-16.png",
+    "48": "icons/icon-48.png",
+    "128": "icons/icon-128.png"
   },
   "side_panel": {
     "default_path": "sidepanel.html"


### PR DESCRIPTION
## Problem

Chrome extension `trios-ext` fails to load: **manifest invalid**. After the ring-isolation restructure (`863d17b`), `manifest.json` was changed to point all icons at `icons/icon.svg`. **Chrome MV3 does not support SVG for `icons` and `default_icon`** — it requires PNG (or BMP/ICO/JPEG). As a result the extension cannot be registered and the sidepanel doesn't open.

## Root cause

```json
"action": { "default_icon": { "16": "icons/icon.svg", "48": "icons/icon.svg", "128": "icons/icon.svg" } },
"icons":  { "16": "icons/icon.svg", "48": "icons/icon.svg", "128": "icons/icon.svg" }
```

Meanwhile the correct PNGs already exist on disk in `crates/trios-ext/extension/icons/`:
- `icon-16.png`
- `icon-48.png`
- `icon-128.png`

(SVGs `icon.svg` and `trinity-icon.svg` are kept for documentation/UI, not for manifest.)

## Fix

Switch all `icons` and `action.default_icon` entries to the per-size PNGs:

```json
"action": {
  "default_title": "Trinity Agent Bridge",
  "default_icon": {
    "16": "icons/icon-16.png",
    "48": "icons/icon-48.png",
    "128": "icons/icon-128.png"
  }
},
"icons": {
  "16": "icons/icon-16.png",
  "48": "icons/icon-48.png",
  "128": "icons/icon-128.png"
}
```

Bumped `version` 0.3.0 → 0.3.1 (icons/manifest patch).

All other manifest fields (permissions, host_permissions, background, side_panel, content_scripts, content_security_policy with `wasm-unsafe-eval`, web_accessible_resources) are preserved verbatim.

## Trinity Stack Laws

- **L1 Atomic PR**: single file, single scope (manifest icons). No mixed scopes.
- **L1 no .sh**: none touched.
- **L7 Tests**: manifest-only change; verified by loading unpacked extension in Chrome — registers successfully and sidepanel opens.
- **L8 PUSH FIRST**: pushed to `fix/trios-ext-icons-png` before opening this PR.

## Gates

- [x] `cargo fmt` — N/A (JSON only)
- [x] `cargo clippy -D warnings` — N/A (JSON only)
- [x] `cargo test` — unaffected
- [x] wasm32 build — unaffected
- [x] no inline JS introduced
- [x] manifest validates against Chrome MV3 schema

## Verification

```
cd /Users/playra/trios/crates/trios-ext/extension
# chrome://extensions/ → Load unpacked → select this dir
# Should show Trinity Agent Bridge with icon, sidepanel opens.
```
