### PR TITLE
feat(#238): scaffold rings/ for trios-phi-schedule — PS-00 PS-01 BR-OUTPUT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,6 +4857,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "trios-phi-schedule-broutput"
+version = "0.1.0"
+
+[[package]]
+name = "trios-phi-schedule-ps00"
+version = "0.1.0"
+
+[[package]]
+name = "trios-phi-schedule-ps01"
+version = "0.1.0"
+
+[[package]]
 name = "trios-physics"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,10 @@ members = [
     "vendor/tri-mcp/rings/SR-00",
     "vendor/tri-mcp/rings/SR-01",
     "vendor/tri-mcp/rings/SR-02",
-    # ORDER-4 (#238) — trios-gb rings
-    "crates/trios-gb/rings/GB-00",
-    "crates/trios-gb/rings/GB-01",
-    "crates/trios-gb/rings/BR-OUTPUT",
+    # ORDER-4 (#238) — trios-phi-schedule rings
+    "crates/trios-phi-schedule/rings/PS-00",
+    "crates/trios-phi-schedule/rings/PS-01",
+    "crates/trios-phi-schedule/rings/BR-OUTPUT",
 ]
 exclude = [
     "crates/trios-ext",

--- a/crates/trios-phi-schedule/RING.md
+++ b/crates/trios-phi-schedule/RING.md
@@ -1,0 +1,42 @@
+# RING — trios-phi-schedule
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Type  | Crate (rings scaffolded for issue #238) |
+| Sealed | No |
+
+## Purpose
+
+phi-modulated schedule and executor rings for trios-phi-schedule — scaffolded under L-ARCH-001.
+
+## Ring Structure (L-ARCH-001)
+
+Rings: PS-00 (schedule), PS-01 (executor), BR-OUTPUT (output)
+
+```
+crates/trios-phi-schedule/
+├── src/                 ← existing logic (untouched, re-export facade)
+└── rings/               ← scaffolded for issue #238 (additive)
+    ├── PS-00/  ← schedule
+    ├── PS-01/  ← executor
+    ├── BR-OUTPUT/  ← output
+```
+
+## Dependency flow
+
+```
+BR-OUTPUT → PS-01 → PS-00
+```
+
+## Anchor
+
+`phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change to parent `src/`
+- L-ARCH-001: `rings/` is the future home of all logic

--- a/crates/trios-phi-schedule/rings/BR-OUTPUT/AGENTS.md
+++ b/crates/trios-phi-schedule/rings/BR-OUTPUT/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — BR-OUTPUT
+
+## Context
+
+This is the `output` ring of `trios-phi-schedule`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `output` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-phi-schedule/rings/BR-OUTPUT/Cargo.toml
+++ b/crates/trios-phi-schedule/rings/BR-OUTPUT/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-phi-schedule-broutput"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "BR-OUTPUT — output ring for trios-phi-schedule"
+publish = false

--- a/crates/trios-phi-schedule/rings/BR-OUTPUT/RING.md
+++ b/crates/trios-phi-schedule/rings/BR-OUTPUT/RING.md
@@ -1,0 +1,26 @@
+# RING — BR-OUTPUT (trios-phi-schedule)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-phi-schedule-broutput |
+| Sealed | No |
+
+## Purpose
+
+`output` ring for `trios-phi-schedule`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `output` concern of `trios-phi-schedule`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-phi-schedule/rings/BR-OUTPUT/TASK.md
+++ b/crates/trios-phi-schedule/rings/BR-OUTPUT/TASK.md
@@ -1,0 +1,11 @@
+# TASK — BR-OUTPUT
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `output` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-phi-schedule/rings/BR-OUTPUT/src/lib.rs
+++ b/crates/trios-phi-schedule/rings/BR-OUTPUT/src/lib.rs
@@ -1,0 +1,20 @@
+//! BR-OUTPUT — output
+//!
+//! Ring scaffold for `trios-phi-schedule`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "BR-OUTPUT"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "BR-OUTPUT");
+    }
+}

--- a/crates/trios-phi-schedule/rings/PS-00/AGENTS.md
+++ b/crates/trios-phi-schedule/rings/PS-00/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — PS-00
+
+## Context
+
+This is the `schedule` ring of `trios-phi-schedule`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `schedule` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-phi-schedule/rings/PS-00/Cargo.toml
+++ b/crates/trios-phi-schedule/rings/PS-00/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-phi-schedule-ps00"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "PS-00 — schedule ring for trios-phi-schedule"
+publish = false

--- a/crates/trios-phi-schedule/rings/PS-00/RING.md
+++ b/crates/trios-phi-schedule/rings/PS-00/RING.md
@@ -1,0 +1,26 @@
+# RING — PS-00 (trios-phi-schedule)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-phi-schedule-ps00 |
+| Sealed | No |
+
+## Purpose
+
+`schedule` ring for `trios-phi-schedule`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `schedule` concern of `trios-phi-schedule`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-phi-schedule/rings/PS-00/TASK.md
+++ b/crates/trios-phi-schedule/rings/PS-00/TASK.md
@@ -1,0 +1,11 @@
+# TASK — PS-00
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `schedule` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-phi-schedule/rings/PS-00/src/lib.rs
+++ b/crates/trios-phi-schedule/rings/PS-00/src/lib.rs
@@ -1,0 +1,20 @@
+//! PS-00 — schedule
+//!
+//! Ring scaffold for `trios-phi-schedule`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "PS-00"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "PS-00");
+    }
+}

--- a/crates/trios-phi-schedule/rings/PS-01/AGENTS.md
+++ b/crates/trios-phi-schedule/rings/PS-01/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — PS-01
+
+## Context
+
+This is the `executor` ring of `trios-phi-schedule`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `executor` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-phi-schedule/rings/PS-01/Cargo.toml
+++ b/crates/trios-phi-schedule/rings/PS-01/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-phi-schedule-ps01"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "PS-01 — executor ring for trios-phi-schedule"
+publish = false

--- a/crates/trios-phi-schedule/rings/PS-01/RING.md
+++ b/crates/trios-phi-schedule/rings/PS-01/RING.md
@@ -1,0 +1,26 @@
+# RING — PS-01 (trios-phi-schedule)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-phi-schedule-ps01 |
+| Sealed | No |
+
+## Purpose
+
+`executor` ring for `trios-phi-schedule`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `executor` concern of `trios-phi-schedule`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-phi-schedule/rings/PS-01/TASK.md
+++ b/crates/trios-phi-schedule/rings/PS-01/TASK.md
@@ -1,0 +1,11 @@
+# TASK — PS-01
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `executor` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-phi-schedule/rings/PS-01/src/lib.rs
+++ b/crates/trios-phi-schedule/rings/PS-01/src/lib.rs
@@ -1,0 +1,20 @@
+//! PS-01 — executor
+//!
+//! Ring scaffold for `trios-phi-schedule`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "PS-01"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "PS-01");
+    }
+}


### PR DESCRIPTION
## Summary

Additive ring scaffold for **trios-phi-schedule** under L-ARCH-001 / Issue #238.
Crate `src/` is untouched; rings are added as parallel workspace members.

## Rings

`PS-00` (schedule), `PS-01` (executor), `BR-OUTPUT` (output)

## Packages

`trios-phi-schedule-ps00` `trios-phi-schedule-ps01` `trios-phi-schedule-broutput`

## Compliance (R1, R5, R9, L7)

- **R1 / R5 / R9** — ring isolation: each ring is a workspace member, no sibling imports
- **L7** — additive only: parent crate `src/` is unchanged
- **Invariant I5** — every ring has `RING.md`, `AGENTS.md`, `TASK.md`
- `cargo check -p trios-phi-schedule-ps00 -p trios-phi-schedule-ps01 -p trios-phi-schedule-broutput` ✅

## Refs

- Closes part of #238
- PR is **draft** — operator merges (no self-merge per ORDER-4)

---

Anchor: `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
