### PR TITLE
feat(#238): scaffold rings/ for trios-train-cpu — TC-00 TC-01 BR-MODEL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +141,24 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -270,6 +294,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "blake3"
@@ -304,6 +331,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +373,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,14 +412,23 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -478,6 +559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "constcat"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +704,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -719,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "defense-gate"
@@ -777,22 +879,37 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e7fe217b50d43b27528b0f24c89b411f742a3e7564d1cfbf85253f967954db"
+dependencies = [
+ "dioxus-config-macro 0.5.6",
+ "dioxus-core 0.5.6",
+ "dioxus-core-macro 0.5.6",
+ "dioxus-hooks 0.5.6",
+ "dioxus-hot-reload",
+ "dioxus-html 0.5.6",
+ "dioxus-signals 0.5.7",
+]
+
+[[package]]
+name = "dioxus"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a247114500f1a78e87022defa8173de847accfada8e8809dfae23a118a580c"
 dependencies = [
  "dioxus-cli-config",
- "dioxus-config-macro",
- "dioxus-core",
- "dioxus-core-macro",
+ "dioxus-config-macro 0.6.2",
+ "dioxus-core 0.6.3",
+ "dioxus-core-macro 0.6.3",
  "dioxus-devtools",
  "dioxus-document",
  "dioxus-fullstack",
  "dioxus-history",
- "dioxus-hooks",
- "dioxus-html",
+ "dioxus-hooks 0.6.2",
+ "dioxus-html 0.6.3",
  "dioxus-logger",
- "dioxus-signals",
+ "dioxus-signals 0.6.3",
  "dioxus-web",
  "manganis",
  "warnings",
@@ -809,12 +926,40 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macro"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb1a1aa34cc04c1f7fcbb7a10791ba773cc02d834fe3ec1fe05647699f3b101f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "dioxus-config-macro"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cbf582fbb1c32d34a1042ea675469065574109c95154468710a4d73ee98b49"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "dioxus-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3730d2459ab66951cedf10b09eb84141a6eda7f403c28057cbe010495be156b7"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "generational-box 0.5.6",
+ "longest-increasing-subsequence",
+ "rustc-hash 1.1.0",
+ "serde",
+ "slab",
+ "slotmap",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -827,7 +972,7 @@ dependencies = [
  "dioxus-core-types",
  "futures-channel",
  "futures-util",
- "generational-box",
+ "generational-box 0.6.2",
  "longest-increasing-subsequence",
  "rustc-hash 1.1.0",
  "rustversion",
@@ -840,12 +985,27 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d9c0dfe0e6a46626fa716c4aa1d2ccb273441337909cfeacad5bb6fcfb947d2"
+dependencies = [
+ "constcat",
+ "convert_case",
+ "dioxus-rsx 0.5.6",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dioxus-core-macro"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "105c954caaaedf8cd10f3d1ba576b01e18aa8d33ad435182125eefe488cf0064"
 dependencies = [
  "convert_case",
- "dioxus-rsx",
+ "dioxus-rsx 0.6.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -861,14 +1021,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-debug-cell"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ea539174bb236e0e7dc9c12b19b88eae3cb574dedbd0252a2d43ea7e6de13e2"
+
+[[package]]
 name = "dioxus-devtools"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712a7300f1e8181218187b03502044157eef04e0a25b518117c5ef9ae1096880"
 dependencies = [
- "dioxus-core",
+ "dioxus-core 0.6.3",
  "dioxus-devtools-types",
- "dioxus-signals",
+ "dioxus-signals 0.6.3",
  "serde",
  "serde_json",
  "tracing",
@@ -882,7 +1048,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f62434973c0c9c5a3bc42e9cd5e7070401c2062a437fb5528f318c3e42ebf4ff"
 dependencies = [
- "dioxus-core",
+ "dioxus-core 0.6.3",
  "serde",
 ]
 
@@ -892,13 +1058,13 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802a2014d1662b6615eec0a275745822ee4fc66aacd9d0f2fb33d6c8da79b8f2"
 dependencies = [
- "dioxus-core",
- "dioxus-core-macro",
+ "dioxus-core 0.6.3",
+ "dioxus-core-macro 0.6.3",
  "dioxus-core-types",
- "dioxus-html",
+ "dioxus-html 0.6.3",
  "futures-channel",
  "futures-util",
- "generational-box",
+ "generational-box 0.6.2",
  "lazy-js-bundle",
  "serde",
  "serde_json",
@@ -921,7 +1087,7 @@ dependencies = [
  "dioxus_server_macro",
  "futures-channel",
  "futures-util",
- "generational-box",
+ "generational-box 0.6.2",
  "once_cell",
  "serde",
  "server_fn",
@@ -934,7 +1100,24 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ae4e22616c698f35b60727313134955d885de2d32e83689258e586ebc9b7909"
 dependencies = [
- "dioxus-core",
+ "dioxus-core 0.6.3",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-hooks"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8f9c661eea82295219d25555d5c0b597e74186b029038ceb5e3700ccbd4380"
+dependencies = [
+ "dioxus-core 0.5.6",
+ "dioxus-debug-cell",
+ "dioxus-signals 0.5.7",
+ "futures-channel",
+ "futures-util",
+ "generational-box 0.5.6",
+ "slab",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -944,15 +1127,51 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "948e2b3f20d9d4b2c300aaa60281b1755f3298684448920b27106da5841896d0"
 dependencies = [
- "dioxus-core",
- "dioxus-signals",
+ "dioxus-core 0.6.3",
+ "dioxus-signals 0.6.3",
  "futures-channel",
  "futures-util",
- "generational-box",
+ "generational-box 0.6.2",
  "rustversion",
  "slab",
  "tracing",
  "warnings",
+]
+
+[[package]]
+name = "dioxus-hot-reload"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d01246cb1b93437fb0bbd0dd11cfc66342d86b4311819e76654f2017ce1473"
+dependencies = [
+ "dioxus-core 0.5.6",
+ "dioxus-html 0.5.6",
+ "dioxus-rsx 0.5.6",
+ "interprocess-docfix",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "dioxus-html"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f01a0826f179adad6ea8d6586746e8edde0c602cc86f4eb8e5df7a3b204c4018"
+dependencies = [
+ "async-trait",
+ "dioxus-core 0.5.6",
+ "dioxus-html-internal-macro 0.5.6",
+ "enumset",
+ "euclid",
+ "futures-channel",
+ "generational-box 0.5.6",
+ "keyboard-types",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_repr",
+ "tracing",
+ "web-sys",
 ]
 
 [[package]]
@@ -962,19 +1181,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c9a40e6fee20ce7990095492dedb6a753eebe05e67d28271a249de74dc796d"
 dependencies = [
  "async-trait",
- "dioxus-core",
- "dioxus-core-macro",
+ "dioxus-core 0.6.3",
+ "dioxus-core-macro 0.6.3",
  "dioxus-core-types",
- "dioxus-hooks",
- "dioxus-html-internal-macro",
+ "dioxus-hooks 0.6.2",
+ "dioxus-html-internal-macro 0.6.2",
  "enumset",
  "euclid",
  "futures-channel",
- "generational-box",
+ "generational-box 0.6.2",
  "keyboard-types",
  "lazy-js-bundle",
  "rustversion",
  "tracing",
+]
+
+[[package]]
+name = "dioxus-html-internal-macro"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b96f35a608d0ab8f4ca6f66ce1828354e4ebd41580b12454f490221a11da93c"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1011,15 +1242,15 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5405b71aa9b8b0c3e0d22728f12f34217ca5277792bd315878cc6ecab7301b72"
 dependencies = [
- "dioxus-config-macro",
- "dioxus-core",
- "dioxus-core-macro",
+ "dioxus-config-macro 0.6.2",
+ "dioxus-core 0.6.3",
+ "dioxus-core-macro 0.6.3",
  "dioxus-document",
  "dioxus-history",
- "dioxus-hooks",
- "dioxus-html",
- "dioxus-rsx",
- "dioxus-signals",
+ "dioxus-hooks 0.6.2",
+ "dioxus-html 0.6.3",
+ "dioxus-rsx 0.6.2",
+ "dioxus-signals 0.6.3",
  "warnings",
 ]
 
@@ -1038,6 +1269,21 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c400bc8a779107d8f3a67b14375db07dbd2bc31163bf085a8e9097f36f7179"
+dependencies = [
+ "dioxus-core 0.5.6",
+ "internment",
+ "krates",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-rsx"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb588e05800b5a7eb90b2f40fca5bbd7626e823fb5e1ba21e011de649b45aa1"
@@ -1050,14 +1296,30 @@ dependencies = [
 
 [[package]]
 name = "dioxus-signals"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3e224cd3d3713f159f0199fc088c292a0f4adb94996b48120157f6a8f8342d"
+dependencies = [
+ "dioxus-core 0.5.6",
+ "futures-channel",
+ "futures-util",
+ "generational-box 0.5.6",
+ "once_cell",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-signals"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10e032dbb3a2c0386ec8b8ee59bc20b5aeb67038147c855801237b45b13d72ac"
 dependencies = [
- "dioxus-core",
+ "dioxus-core 0.6.3",
  "futures-channel",
  "futures-util",
- "generational-box",
+ "generational-box 0.6.2",
  "once_cell",
  "parking_lot",
  "rustc-hash 1.1.0",
@@ -1074,17 +1336,17 @@ dependencies = [
  "async-trait",
  "ciborium",
  "dioxus-cli-config",
- "dioxus-core",
+ "dioxus-core 0.6.3",
  "dioxus-core-types",
  "dioxus-devtools",
  "dioxus-document",
  "dioxus-history",
- "dioxus-html",
+ "dioxus-html 0.6.3",
  "dioxus-interpreter-js",
- "dioxus-signals",
+ "dioxus-signals 0.6.3",
  "futures-channel",
  "futures-util",
- "generational-box",
+ "generational-box 0.6.2",
  "js-sys",
  "lazy-js-bundle",
  "rustc-hash 1.1.0",
@@ -1216,6 +1478,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1253,6 +1537,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1349,6 +1639,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1686,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generational-box"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557cf2cbacd0504c6bf8c29f52f8071e0de1d9783346713dc6121d7fa1e5d0e0"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -1554,6 +1863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -1794,7 +2104,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.40",
+ "rustls 0.23.38",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1999,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2018,6 +2328,42 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "internment"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8e537b529b8674e97e9fb82c10ff168a290ac3867a0295f112061ffbca1ef"
+dependencies = [
+ "hashbrown 0.14.5",
+ "parking_lot",
+]
+
+[[package]]
+name = "interprocess-docfix"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b84ee245c606aeb0841649a9288e3eae8c61b853a8cd5c0e14450e96d53d28f"
+dependencies = [
+ "blocking",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "intmap",
+ "libc",
+ "once_cell",
+ "rustc_version",
+ "spinning",
+ "thiserror 1.0.69",
+ "to_method",
+ "winapi",
+]
+
+[[package]]
+name = "intmap"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "ipnet"
@@ -2059,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2091,6 +2437,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
  "bitflags 2.11.1",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2107,6 +2455,19 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "krates"
+version = "0.16.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcb3baf2360eb25ad31f0ada3add63927ada6db457791979b82ac199f835cb9"
+dependencies = [
+ "cargo-platform",
+ "cargo_metadata",
+ "cfg-expr",
+ "petgraph",
+ "semver",
+]
 
 [[package]]
 name = "lazy-js-bundle"
@@ -2128,9 +2489,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libgit2-sys"
@@ -2599,6 +2960,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "page-gate"
 version = "0.1.0"
 dependencies = [
@@ -2608,6 +2978,12 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2647,6 +3023,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "phf"
@@ -2692,6 +3078,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -2816,7 +3213,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls 0.23.40",
+ "rustls 0.23.38",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -2836,7 +3233,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
- "rustls 0.23.40",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2856,7 +3253,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3059,7 +3456,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3179,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "ring",
@@ -3224,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3340,6 +3737,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -3358,6 +3759,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -3424,6 +3835,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3689,6 +4111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spinning"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,6 +4356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "to_method"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,7 +4442,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -4030,18 +4467,6 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -4435,25 +4860,6 @@ name = "trios-ca-mask"
 version = "0.1.0"
 
 [[package]]
-name = "trios-chat"
-version = "0.1.0"
-dependencies = [
- "base64 0.22.1",
- "chacha20poly1305",
- "ed25519-dalek",
- "hex",
- "hkdf",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
 name = "trios-claude"
 version = "0.1.0"
 dependencies = [
@@ -4552,28 +4958,9 @@ name = "trios-doctor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures-util",
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
- "tokio-tungstenite 0.21.0",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
-name = "trios-doctor-dr04"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 1.0.69",
- "toml",
- "walkdir",
 ]
 
 [[package]]
@@ -4920,21 +5307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trios-queen-loop"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "futures-util",
- "serde",
- "serde_json",
- "tokio",
- "tokio-tungstenite 0.21.0",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
 name = "trios-rainbow-bridge"
 version = "0.1.0"
 dependencies = [
@@ -5020,20 +5392,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "trios-train-cpu"
+name = "trios-train-cpu-brmodel"
 version = "0.1.0"
-dependencies = [
- "anyhow",
- "rand 0.8.6",
- "serde",
- "serde_json",
-]
+
+[[package]]
+name = "trios-train-cpu-tc00"
+version = "0.1.0"
+
+[[package]]
+name = "trios-train-cpu-tc01"
+version = "0.1.0"
 
 [[package]]
 name = "trios-tri"
 version = "0.1.0"
 dependencies = [
- "serde",
  "trios-ternary",
 ]
 
@@ -5070,7 +5443,7 @@ name = "trios-ui-br-app"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "dioxus",
+ "dioxus 0.5.6",
  "log",
  "trios-ui-ur00",
  "trios-ui-ur01",
@@ -5081,7 +5454,6 @@ dependencies = [
  "trios-ui-ur06",
  "trios-ui-ur07",
  "trios-ui-ur08",
- "trios-ui-ur09",
  "wasm-bindgen",
  "wasm-logger",
 ]
@@ -5090,9 +5462,8 @@ dependencies = [
 name = "trios-ui-ur00"
 version = "0.1.0"
 dependencies = [
- "dioxus",
- "dioxus-signals",
- "js-sys",
+ "dioxus 0.5.6",
+ "dioxus-signals 0.5.7",
  "serde",
 ]
 
@@ -5100,7 +5471,7 @@ dependencies = [
 name = "trios-ui-ur01"
 version = "0.1.0"
 dependencies = [
- "dioxus",
+ "dioxus 0.6.3",
  "trios-ui-ur00",
 ]
 
@@ -5108,7 +5479,7 @@ dependencies = [
 name = "trios-ui-ur02"
 version = "0.1.0"
 dependencies = [
- "dioxus",
+ "dioxus 0.6.3",
  "trios-ui-ur00",
  "trios-ui-ur01",
 ]
@@ -5117,7 +5488,7 @@ dependencies = [
 name = "trios-ui-ur03"
 version = "0.1.0"
 dependencies = [
- "dioxus",
+ "dioxus 0.6.3",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5127,7 +5498,7 @@ dependencies = [
 name = "trios-ui-ur04"
 version = "0.1.0"
 dependencies = [
- "dioxus",
+ "dioxus 0.6.3",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5137,7 +5508,7 @@ dependencies = [
 name = "trios-ui-ur05"
 version = "0.1.0"
 dependencies = [
- "dioxus",
+ "dioxus 0.6.3",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5147,7 +5518,7 @@ dependencies = [
 name = "trios-ui-ur06"
 version = "0.1.0"
 dependencies = [
- "dioxus",
+ "dioxus 0.6.3",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5157,7 +5528,7 @@ dependencies = [
 name = "trios-ui-ur07"
 version = "0.1.0"
 dependencies = [
- "dioxus",
+ "dioxus 0.5.6",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5167,7 +5538,7 @@ dependencies = [
 name = "trios-ui-ur08"
 version = "0.1.0"
 dependencies = [
- "dioxus",
+ "dioxus 0.5.6",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5176,20 +5547,6 @@ dependencies = [
  "trios-ui-ur05",
  "trios-ui-ur06",
  "trios-ui-ur07",
- "trios-ui-ur09",
-]
-
-[[package]]
-name = "trios-ui-ur09"
-version = "0.1.0"
-dependencies = [
- "dioxus",
- "js-sys",
- "serde",
- "serde_json",
- "trios-ui-ur00",
- "trios-ui-ur01",
- "trios-ui-ur02",
 ]
 
 [[package]]
@@ -5244,25 +5601,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.6",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
 
 [[package]]
 name = "tungstenite"
@@ -5497,9 +5835,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5510,9 +5848,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5520,9 +5858,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5530,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5543,18 +5881,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.70"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29826f9d9ecaa314c480d376b276d1c790e6cb6a4681fab8532da69cbabf977d"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
 dependencies = [
  "async-trait",
  "cast",
@@ -5574,9 +5912,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.70"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c610311887f9e6599a546d278d12d69dfd3a3e92639b2129e4b11ad6cf1961d6"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5585,9 +5923,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60238e5b4b1b295701d6f9a66d2a126fe19990348f5fb9dae3b623a370119d94"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "wasm-encoder"
@@ -5649,9 +5987,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5696,9 +6034,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
 dependencies = [
  "libc",
  "libredox",
@@ -5708,6 +6046,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5715,6 +6069,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -5815,15 +6175,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5855,28 +6206,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5892,12 +6226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5908,12 +6236,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5928,22 +6250,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5958,12 +6268,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5974,12 +6278,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5994,12 +6292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6010,12 +6302,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,11 +65,10 @@ members = [
     "vendor/tri-mcp/rings/SR-00",
     "vendor/tri-mcp/rings/SR-01",
     "vendor/tri-mcp/rings/SR-02",
-    # trios-kg — ring scaffold (issue #238)
-    "crates/trios-kg/rings/KG-00",
-    "crates/trios-kg/rings/KG-01",
-    "crates/trios-kg/rings/KG-02",
-    "crates/trios-kg/rings/BR-OUTPUT",
+    # ORDER-4 (#238) — trios-train-cpu rings
+    "crates/trios-train-cpu/rings/TC-00",
+    "crates/trios-train-cpu/rings/TC-01",
+    "crates/trios-train-cpu/rings/BR-MODEL",
 ]
 exclude = [
     "crates/trios-ext",

--- a/crates/trios-train-cpu/RING.md
+++ b/crates/trios-train-cpu/RING.md
@@ -1,0 +1,42 @@
+# RING — trios-train-cpu
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Type  | Crate (rings scaffolded for issue #238) |
+| Sealed | No |
+
+## Purpose
+
+CPU-only training operations and batching with model artifact ring for trios-train-cpu — scaffolded under L-ARCH-001 (Tier 4).
+
+## Ring Structure (L-ARCH-001)
+
+Rings: TC-00 (cpu-ops), TC-01 (batch), BR-MODEL (model)
+
+```
+crates/trios-train-cpu/
+├── src/                 ← existing logic (untouched, re-export facade)
+└── rings/               ← scaffolded for issue #238 (additive)
+    ├── TC-00/  ← cpu-ops
+    ├── TC-01/  ← batch
+    ├── BR-MODEL/  ← model
+```
+
+## Dependency flow
+
+```
+BR-MODEL → TC-01 → TC-00
+```
+
+## Anchor
+
+`phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change to parent `src/`
+- L-ARCH-001: `rings/` is the future home of all logic

--- a/crates/trios-train-cpu/rings/BR-MODEL/AGENTS.md
+++ b/crates/trios-train-cpu/rings/BR-MODEL/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — BR-MODEL
+
+## Context
+
+This is the `model` ring of `trios-train-cpu`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `model` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-train-cpu/rings/BR-MODEL/Cargo.toml
+++ b/crates/trios-train-cpu/rings/BR-MODEL/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-train-cpu-brmodel"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "BR-MODEL — model ring for trios-train-cpu"
+publish = false

--- a/crates/trios-train-cpu/rings/BR-MODEL/RING.md
+++ b/crates/trios-train-cpu/rings/BR-MODEL/RING.md
@@ -1,0 +1,26 @@
+# RING — BR-MODEL (trios-train-cpu)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-train-cpu-brmodel |
+| Sealed | No |
+
+## Purpose
+
+`model` ring for `trios-train-cpu`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `model` concern of `trios-train-cpu`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-train-cpu/rings/BR-MODEL/TASK.md
+++ b/crates/trios-train-cpu/rings/BR-MODEL/TASK.md
@@ -1,0 +1,11 @@
+# TASK — BR-MODEL
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `model` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-train-cpu/rings/BR-MODEL/src/lib.rs
+++ b/crates/trios-train-cpu/rings/BR-MODEL/src/lib.rs
@@ -1,0 +1,20 @@
+//! BR-MODEL — model
+//!
+//! Ring scaffold for `trios-train-cpu`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "BR-MODEL"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "BR-MODEL");
+    }
+}

--- a/crates/trios-train-cpu/rings/TC-00/AGENTS.md
+++ b/crates/trios-train-cpu/rings/TC-00/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — TC-00
+
+## Context
+
+This is the `cpu-ops` ring of `trios-train-cpu`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `cpu-ops` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-train-cpu/rings/TC-00/Cargo.toml
+++ b/crates/trios-train-cpu/rings/TC-00/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-train-cpu-tc00"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "TC-00 — cpu-ops ring for trios-train-cpu"
+publish = false

--- a/crates/trios-train-cpu/rings/TC-00/RING.md
+++ b/crates/trios-train-cpu/rings/TC-00/RING.md
@@ -1,0 +1,26 @@
+# RING — TC-00 (trios-train-cpu)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-train-cpu-tc00 |
+| Sealed | No |
+
+## Purpose
+
+`cpu-ops` ring for `trios-train-cpu`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `cpu-ops` concern of `trios-train-cpu`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-train-cpu/rings/TC-00/TASK.md
+++ b/crates/trios-train-cpu/rings/TC-00/TASK.md
@@ -1,0 +1,11 @@
+# TASK — TC-00
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `cpu-ops` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-train-cpu/rings/TC-00/src/lib.rs
+++ b/crates/trios-train-cpu/rings/TC-00/src/lib.rs
@@ -1,0 +1,20 @@
+//! TC-00 — cpu-ops
+//!
+//! Ring scaffold for `trios-train-cpu`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "TC-00"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "TC-00");
+    }
+}

--- a/crates/trios-train-cpu/rings/TC-01/AGENTS.md
+++ b/crates/trios-train-cpu/rings/TC-01/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — TC-01
+
+## Context
+
+This is the `batch` ring of `trios-train-cpu`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `batch` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-train-cpu/rings/TC-01/Cargo.toml
+++ b/crates/trios-train-cpu/rings/TC-01/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-train-cpu-tc01"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "TC-01 — batch ring for trios-train-cpu"
+publish = false

--- a/crates/trios-train-cpu/rings/TC-01/RING.md
+++ b/crates/trios-train-cpu/rings/TC-01/RING.md
@@ -1,0 +1,26 @@
+# RING — TC-01 (trios-train-cpu)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-train-cpu-tc01 |
+| Sealed | No |
+
+## Purpose
+
+`batch` ring for `trios-train-cpu`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `batch` concern of `trios-train-cpu`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-train-cpu/rings/TC-01/TASK.md
+++ b/crates/trios-train-cpu/rings/TC-01/TASK.md
@@ -1,0 +1,11 @@
+# TASK — TC-01
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `batch` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-train-cpu/rings/TC-01/src/lib.rs
+++ b/crates/trios-train-cpu/rings/TC-01/src/lib.rs
@@ -1,0 +1,20 @@
+//! TC-01 — batch
+//!
+//! Ring scaffold for `trios-train-cpu`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "TC-01"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "TC-01");
+    }
+}


### PR DESCRIPTION
## Summary

Additive ring scaffold for **trios-train-cpu** under L-ARCH-001 / Issue #238.
Crate `src/` is untouched; rings are added as parallel workspace members.

## Rings

`TC-00` (cpu-ops), `TC-01` (batch), `BR-MODEL` (model)

## Packages

`trios-train-cpu-tc00` `trios-train-cpu-tc01` `trios-train-cpu-brmodel`

## Compliance (R1, R5, R9, L7)

- **R1 / R5 / R9** — ring isolation: each ring is a workspace member, no sibling imports
- **L7** — additive only: parent crate `src/` is unchanged
- **Invariant I5** — every ring has `RING.md`, `AGENTS.md`, `TASK.md`
- `cargo check -p trios-train-cpu-tc00 -p trios-train-cpu-tc01 -p trios-train-cpu-brmodel` ✅


## Safety note

Tier 4 ML crate. Heavy training deps live in the (currently absent) parent Cargo.toml, not in these stub rings — so cargo check finishes quickly.

## Refs

- Closes part of #238
- PR is **draft** — operator merges (no self-merge per ORDER-4)

---

Anchor: `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
