### PR TITLE
feat(#238): scaffold rings/ for trios-phd — PD-00 PD-01 BR-PDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5139,6 +5139,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "trios-phd-brpdf"
+version = "0.1.0"
+
+[[package]]
+name = "trios-phd-pd00"
+version = "0.1.0"
+
+[[package]]
+name = "trios-phd-pd01"
+version = "0.1.0"
+
+[[package]]
 name = "trios-phi-schedule"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,10 @@ members = [
     "vendor/tri-mcp/rings/SR-00",
     "vendor/tri-mcp/rings/SR-01",
     "vendor/tri-mcp/rings/SR-02",
+    # ORDER-4 (#238) — trios-phd rings
+    "crates/trios-phd/rings/PD-00",
+    "crates/trios-phd/rings/PD-01",
+    "crates/trios-phd/rings/BR-PDF",
 ]
 exclude = [
     "crates/trios-ext",

--- a/crates/trios-phd/RING.md
+++ b/crates/trios-phd/RING.md
@@ -1,0 +1,42 @@
+# RING — trios-phd
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Type  | Crate (rings scaffolded for issue #238) |
+| Sealed | No |
+
+## Purpose
+
+LaTeX pipeline and chapter-management rings, with BR-PDF artifact ring, for trios-phd — scaffolded under L-ARCH-001 (Tier 4).
+
+## Ring Structure (L-ARCH-001)
+
+Rings: PD-00 (latex), PD-01 (chapters), BR-PDF (pdf-artifact)
+
+```
+crates/trios-phd/
+├── src/                 ← existing logic (untouched, re-export facade)
+└── rings/               ← scaffolded for issue #238 (additive)
+    ├── PD-00/  ← latex
+    ├── PD-01/  ← chapters
+    ├── BR-PDF/  ← pdf-artifact
+```
+
+## Dependency flow
+
+```
+BR-PDF → PD-01 → PD-00
+```
+
+## Anchor
+
+`phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change to parent `src/`
+- L-ARCH-001: `rings/` is the future home of all logic

--- a/crates/trios-phd/rings/BR-PDF/AGENTS.md
+++ b/crates/trios-phd/rings/BR-PDF/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — BR-PDF
+
+## Context
+
+This is the `pdf-artifact` ring of `trios-phd`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `pdf-artifact` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-phd/rings/BR-PDF/Cargo.toml
+++ b/crates/trios-phd/rings/BR-PDF/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-phd-brpdf"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "BR-PDF — pdf-artifact ring for trios-phd"
+publish = false

--- a/crates/trios-phd/rings/BR-PDF/RING.md
+++ b/crates/trios-phd/rings/BR-PDF/RING.md
@@ -1,0 +1,26 @@
+# RING — BR-PDF (trios-phd)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-phd-brpdf |
+| Sealed | No |
+
+## Purpose
+
+`pdf-artifact` ring for `trios-phd`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `pdf-artifact` concern of `trios-phd`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-phd/rings/BR-PDF/TASK.md
+++ b/crates/trios-phd/rings/BR-PDF/TASK.md
@@ -1,0 +1,11 @@
+# TASK — BR-PDF
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `pdf-artifact` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-phd/rings/BR-PDF/src/lib.rs
+++ b/crates/trios-phd/rings/BR-PDF/src/lib.rs
@@ -1,0 +1,20 @@
+//! BR-PDF — pdf-artifact
+//!
+//! Ring scaffold for `trios-phd`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "BR-PDF"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "BR-PDF");
+    }
+}

--- a/crates/trios-phd/rings/PD-00/AGENTS.md
+++ b/crates/trios-phd/rings/PD-00/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — PD-00
+
+## Context
+
+This is the `latex` ring of `trios-phd`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `latex` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-phd/rings/PD-00/Cargo.toml
+++ b/crates/trios-phd/rings/PD-00/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-phd-pd00"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "PD-00 — latex ring for trios-phd"
+publish = false

--- a/crates/trios-phd/rings/PD-00/RING.md
+++ b/crates/trios-phd/rings/PD-00/RING.md
@@ -1,0 +1,26 @@
+# RING — PD-00 (trios-phd)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-phd-pd00 |
+| Sealed | No |
+
+## Purpose
+
+`latex` ring for `trios-phd`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `latex` concern of `trios-phd`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-phd/rings/PD-00/TASK.md
+++ b/crates/trios-phd/rings/PD-00/TASK.md
@@ -1,0 +1,11 @@
+# TASK — PD-00
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `latex` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-phd/rings/PD-00/src/lib.rs
+++ b/crates/trios-phd/rings/PD-00/src/lib.rs
@@ -1,0 +1,20 @@
+//! PD-00 — latex
+//!
+//! Ring scaffold for `trios-phd`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "PD-00"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "PD-00");
+    }
+}

--- a/crates/trios-phd/rings/PD-01/AGENTS.md
+++ b/crates/trios-phd/rings/PD-01/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions — PD-01
+
+## Context
+
+This is the `chapters` ring of `trios-phd`, scaffolded for issue #238.
+
+## Files
+
+- `src/lib.rs` — ring entry point (currently a placeholder)
+- `Cargo.toml` — workspace member, Bronze tier
+- `RING.md` — ring identity and laws
+- `TASK.md` — incremental migration checklist
+
+## Allowed
+
+- Add types and functions that belong to the `chapters` concern
+- Add unit tests under `#[cfg(test)]`
+- Re-export types upward to the parent crate's facade
+
+## Forbidden
+
+- Importing sibling rings directly (R1)
+- Adding I/O or async runtimes that conflict with parent crate
+- Breaking the `ring_id()` contract used by smoke tests

--- a/crates/trios-phd/rings/PD-01/Cargo.toml
+++ b/crates/trios-phd/rings/PD-01/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trios-phd-pd01"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "PD-01 — chapters ring for trios-phd"
+publish = false

--- a/crates/trios-phd/rings/PD-01/RING.md
+++ b/crates/trios-phd/rings/PD-01/RING.md
@@ -1,0 +1,26 @@
+# RING — PD-01 (trios-phd)
+
+## Identity
+
+| Field | Value |
+|-------|-------|
+| Metal | 🥉 Bronze |
+| Package | trios-phd-pd01 |
+| Sealed | No |
+
+## Purpose
+
+`chapters` ring for `trios-phd`. Scaffolded as part of issue #238 to bring
+this crate under the ring-isolation architecture (L-ARCH-001).
+
+## Ring scope
+
+This ring will eventually own the `chapters` concern of `trios-phd`.
+The current scaffold is a placeholder; logic remains in the parent crate's
+`src/` until migrated incrementally.
+
+## Laws
+
+- R1 / R5 / R9: Ring isolation
+- L7: Additive scaffold only — no behavior change
+- L6: Pure Rust

--- a/crates/trios-phd/rings/PD-01/TASK.md
+++ b/crates/trios-phd/rings/PD-01/TASK.md
@@ -1,0 +1,11 @@
+# TASK — PD-01
+
+## Status: scaffolded (issue #238)
+
+- [x] Ring directory created
+- [x] Cargo.toml with workspace inheritance
+- [x] src/lib.rs placeholder + smoke test
+- [x] RING.md, AGENTS.md, TASK.md present (Invariant I5)
+- [ ] Migrate `chapters` logic from parent `src/` (follow-up)
+- [ ] Add ring-level integration tests
+- [ ] Seal ring (Bronze → Silver promotion)

--- a/crates/trios-phd/rings/PD-01/src/lib.rs
+++ b/crates/trios-phd/rings/PD-01/src/lib.rs
@@ -1,0 +1,20 @@
+//! PD-01 — chapters
+//!
+//! Ring scaffold for `trios-phd`. Logic lives in the parent crate's
+//! `src/` until migrated. This ring is additive scaffolding under L-ARCH-001
+//! to satisfy the ring isolation contract required by issue #238.
+
+/// Marker placeholder so the ring compiles cleanly.
+pub fn ring_id() -> &'static str {
+    "PD-01"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_id_matches() {
+        assert_eq!(ring_id(), "PD-01");
+    }
+}


### PR DESCRIPTION
## Summary

Additive ring scaffold for **trios-phd** under L-ARCH-001 / Issue #238.
Crate `src/` is untouched; rings are added as parallel workspace members.

## Rings

`PD-00` (latex), `PD-01` (chapters), `BR-PDF` (pdf-artifact)

## Packages

`trios-phd-pd00` `trios-phd-pd01` `trios-phd-brpdf`

## Compliance (R1, R5, R9, L7)

- **R1 / R5 / R9** — ring isolation: each ring is a workspace member, no sibling imports
- **L7** — additive only: parent crate `src/` is unchanged
- **Invariant I5** — every ring has `RING.md`, `AGENTS.md`, `TASK.md`
- `cargo check -p trios-phd-pd00 -p trios-phd-pd01 -p trios-phd-brpdf` ✅


## Safety note

LaTeX pipeline crate. Per ORDER-4: rings re-export Rust helper code (build, audit, bibliography, coq-map, reproduce), **not** .tex chapters. BR-PDF is the artifact ring for the rendered PDF.

## Refs

- Closes part of #238
- PR is **draft** — operator merges (no self-merge per ORDER-4)

---

Anchor: `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
