### PR TITLE
docs: MCP setup guide, trainer README, UI ring audit (Closes #332, Closes #327, Closes #253)

### DIFF
--- a/crates/trios-train-cpu/README.md
+++ b/crates/trios-train-cpu/README.md
@@ -1,0 +1,65 @@
+# trios-train-cpu
+
+CPU N-gram language model training for IGLA RACE.
+
+## Migration Status
+
+| Phase | Component | Status |
+|-------|-----------|--------|
+| M0 | Crate scaffolding | Partial (no Cargo.toml, no lib.rs) |
+| M1 | muP scaling (`src/mup.rs`) | Done (10 tests) |
+| M2 | LR schedules (`src/schedule.rs`) | Done (6 tests) |
+| M3 | Training loop | Not started |
+| M4 | Data pipeline | Not started |
+| M5 | Tokenizer | Not started |
+| M6 | Checkpoint/eval | Not started |
+| M7 | Gate-2 push (3 seeds < 1.85 BPB) | Not started |
+
+## Training-Flow V2 Plan
+
+| Phase | Goal | Falsifiable Hypothesis |
+|-------|------|----------------------|
+| P0 | Audit: reproduce champion BPB 2.2393 | Exact reproduction on seed 43 |
+| P1 | Optimizer Lab: Muon vs AdamW | Muon beats AdamW by >5% on 8M |
+| P2 | muP Transfer: 8M -> 70M | LR transfer reduces search by 3x |
+| P3 | Schedule-Free + WSD vs cosine | SF/WSD beats cosine by >3% |
+| P4 | Multi-Objective + EMA (JEPA + NCA) | Joint loss < single-task |
+| P5 | Gate-2 Push: 3 seeds < 1.85 | 3 independent seeds under threshold |
+
+## Architecture
+
+```
+trios-train-cpu/
+  src/
+    mup.rs        -- Maximal Update Parametrization scaling
+    schedule.rs   -- LR schedules (Cosine, Schedule-Free, WSD)
+  configs/lab/
+    p2-proxy-8m.toml   -- 8M proxy (d=256, 2L, 4H)
+    p2-proxy-24m.toml  -- 24M transfer (d=384, 3L, 6H)
+    p2-target-70m.toml -- 70M Gate-2 target (d=384, 4L, 6H)
+  assertions/lab/
+    p2_transfer.jsonl  -- muP transfer results (empty)
+```
+
+## Key Types
+
+- `MupConfig` — muP scaling configuration (ref/target width, per-group LR multipliers)
+- `ModelDims` — model dimensions (d_model, n_heads, d_ffn)
+- `ParamGroup` — parameter group enum (Embedding, Output, Attention, FFN, LayerNorm)
+- `ScheduleType` — LR schedule enum (Cosine, ScheduleFree, Wsd)
+- `CosineSchedule` / `WsdSchedule` / `ScheduleFreeState` — schedule implementations
+
+## Configuration
+
+All configs use the Muon optimizer with:
+- `lr = 0.0039`, `warmup = 500 steps`, `max_steps = 12000`
+- `batch_size = 32`, `grad_clip = 1.0`
+- `eta_2d = 0.0235`, `eta_1d = 0.007`, `momentum = 0.95`
+
+## References
+
+- Yang et al. 2022 — Maximal Update Parametrization (muP)
+- Defazio 2024 — Schedule-Free learning
+- Wen 2024 — WSD (Warmup-Stable-Decay) schedule
+
+> phi^2 + phi^-2 = 3 · TRINITY · IGLA-RACE

--- a/crates/trios-ui/rings/UR-03/TASK.md
+++ b/crates/trios-ui/rings/UR-03/TASK.md
@@ -1,0 +1,9 @@
+# UR-03 Tasks
+
+## Current
+- [ ] Sidebar: collapsible with animation
+- [ ] Tabs: keyboard navigation (arrow keys)
+- [ ] Panel: resizable split view
+
+## Done
+- [x] Basic Sidebar/Tabs/Panel layout components

--- a/crates/trios-ui/rings/UR-04/AGENTS.md
+++ b/crates/trios-ui/rings/UR-04/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions UR-04
+
+## What to touch
+- `src/lib.rs` — ChatPanel, ChatBubble, ChatInputBar components
+
+## What NOT to touch
+- UR-00 atom definitions (modify atoms in UR-00, consume here)
+- UR-01 palette values (consume only)
+- UR-02 component internals (use their public API)
+
+## Testing
+- Component rendering via Dioxus test harness
+- Verify ChatBubble renders MessageRole variants (User, Assistant, System, Tool)

--- a/crates/trios-ui/rings/UR-04/RING.md
+++ b/crates/trios-ui/rings/UR-04/RING.md
@@ -1,0 +1,18 @@
+# UR-04 — Chat UI
+
+## Purpose
+Chat panel component for Trinity sidebar: message list with bubbles and input bar.
+
+## Exported Components
+- `ChatPanel()` — full chat panel with message history and input
+- `ChatBubble()` — single message bubble (role-styled)
+- `ChatInputBar()` — text input with send button
+
+## Dependencies
+- UR-00 (chat state atoms)
+- UR-01 (theme/palette tokens)
+- UR-02 (Button, Input primitives)
+
+## Constraints
+- No direct API calls — state flows through UR-00 atoms
+- No CSS hardcoding — use UR-01 design tokens only

--- a/crates/trios-ui/rings/UR-04/TASK.md
+++ b/crates/trios-ui/rings/UR-04/TASK.md
@@ -1,0 +1,9 @@
+# UR-04 Tasks
+
+## Current
+- [ ] ChatPanel: wire scroll-to-bottom on new message
+- [ ] ChatInputBar: handle Enter key, disable on empty input
+- [ ] ChatBubble: markdown rendering for assistant messages
+
+## Done
+- [x] Basic ChatPanel/ChatBubble/ChatInputBar components

--- a/crates/trios-ui/rings/UR-05/AGENTS.md
+++ b/crates/trios-ui/rings/UR-05/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions UR-05
+
+## What to touch
+- `src/lib.rs` — AgentList, AgentCard components
+
+## What NOT to touch
+- UR-00 atom definitions (modify atoms in UR-00, consume here)
+- UR-01 palette values (consume only)
+- UR-02 component internals (use their public API)
+
+## Testing
+- AgentList renders N agent cards from atom state
+- AgentCard displays status badge (Idle/Busy/Error)

--- a/crates/trios-ui/rings/UR-05/RING.md
+++ b/crates/trios-ui/rings/UR-05/RING.md
@@ -1,0 +1,20 @@
+# UR-05 — Agent UI
+
+## Purpose
+Agent list and agent card components for Trinity sidebar.
+
+## Exported Components
+- `AgentList()` — scrollable list of agent cards
+- `AgentCard(props: AgentCardProps)` — single agent status card
+
+## Exported Types
+- `AgentCardProps` — props struct for agent card
+
+## Dependencies
+- UR-00 (agent state atoms)
+- UR-01 (theme/palette tokens)
+- UR-02 (Button, Badge primitives)
+
+## Constraints
+- No direct API calls — state flows through UR-00 atoms
+- No CSS hardcoding — use UR-01 design tokens only

--- a/crates/trios-ui/rings/UR-05/TASK.md
+++ b/crates/trios-ui/rings/UR-05/TASK.md
@@ -1,0 +1,8 @@
+# UR-05 Tasks
+
+## Current
+- [ ] AgentCard: add click handler to select agent
+- [ ] AgentList: filter by status (all/active/idle)
+
+## Done
+- [x] Basic AgentList/AgentCard components

--- a/crates/trios-ui/rings/UR-06/AGENTS.md
+++ b/crates/trios-ui/rings/UR-06/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions UR-06
+
+## What to touch
+- `src/lib.rs` — McpPanel, McpToolCard components
+
+## What NOT to touch
+- UR-00 atom definitions (modify atoms in UR-00, consume here)
+- UR-01 palette values (consume only)
+- UR-02 component internals (use their public API)
+
+## Testing
+- McpPanel renders N tool cards from atom state
+- McpToolCard shows tool name, description, status badge

--- a/crates/trios-ui/rings/UR-06/RING.md
+++ b/crates/trios-ui/rings/UR-06/RING.md
@@ -1,0 +1,20 @@
+# UR-06 — MCP Panel
+
+## Purpose
+MCP tools panel for Trinity sidebar: displays available MCP tools and their status.
+
+## Exported Components
+- `McpPanel()` — full tools panel with tool cards
+- `McpToolCard(props: McpToolCardProps)` — single MCP tool card
+
+## Exported Types
+- `McpToolCardProps` — props struct for tool card
+
+## Dependencies
+- UR-00 (MCP state atoms)
+- UR-01 (theme/palette tokens)
+- UR-02 (Button, Badge primitives)
+
+## Constraints
+- No direct API calls — state flows through UR-00 atoms
+- No CSS hardcoding — use UR-01 design tokens only

--- a/crates/trios-ui/rings/UR-06/TASK.md
+++ b/crates/trios-ui/rings/UR-06/TASK.md
@@ -1,0 +1,8 @@
+# UR-06 Tasks
+
+## Current
+- [ ] McpToolCard: add invoke button with loading state
+- [ ] McpPanel: group tools by server name
+
+## Done
+- [x] Basic McpPanel/McpToolCard components

--- a/docs/mcp/MCP_SETUP_GUIDE.md
+++ b/docs/mcp/MCP_SETUP_GUIDE.md
@@ -1,0 +1,224 @@
+# MCP Setup Guide: Connecting Two MCP Servers to Perplexity (Local + Remote)
+
+> **Status**: Local MCP (Mac app) — available now · Remote MCP — coming soon
+> **Audience**: Developers and agents working on IGLA RACE / Trinity swarm
+> **Platform**: macOS (Mac App Store), Perplexity Pro account required
+
+---
+
+## What is MCP in Perplexity context?
+
+MCP (Model Context Protocol) lets Perplexity connect to external tools, APIs, and services. Think of it as a universal adapter: each MCP server exposes **tools** that Perplexity can call during a conversation.
+
+Two types:
+| Type | Where it runs | Auth | Status |
+|------|--------------|------|--------|
+| **Local MCP** | Your Mac (stdio) | none / local | Available now |
+| **Remote MCP** | Cloud (HTTP/SSE) | Bearer token | Coming soon |
+
+---
+
+## SETUP: Two MCP Servers in Perplexity (Mac App)
+
+### Prerequisites
+
+```bash
+# 1. Install Node.js (required for npx commands)
+brew install node
+
+# 2. Install Perplexity Mac App from Mac App Store
+# https://apps.apple.com/app/perplexity-ask-anything/id1668000334
+
+# 3. Perplexity Pro subscription required
+```
+
+### Step 1 — Install PerplexityXPC Helper
+
+```
+Perplexity App -> Settings -> Connectors -> Install Helper (PerplexityXPC)
+```
+
+This helper allows Perplexity to securely communicate with local MCP servers on your machine.
+
+### Step 2 — Add First MCP Server (GitHub / trios)
+
+```
+Settings -> Connectors -> Add Connector -> Simple tab
+```
+
+| Field | Value |
+|-------|-------|
+| **Server Name** | `trios-github` |
+| **Command** | `npx -y @modelcontextprotocol/server-github` |
+| **Env var** | `GITHUB_TOKEN=ghp_your_token_here` |
+
+Or via **Advanced JSON** tab:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": {
+    "GITHUB_TOKEN": "ghp_your_token_here"
+  }
+}
+```
+
+### Step 3 — Add Second MCP Server (Linear / trios-railway)
+
+```
+Settings -> Connectors -> Add Connector -> Simple tab
+```
+
+| Field | Value |
+|-------|-------|
+| **Server Name** | `trios-linear` |
+| **Command** | `npx -y @linear/mcp-server` |
+| **Env var** | `LINEAR_API_KEY=lin_api_your_key_here` |
+
+Or via **Advanced JSON** tab:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@linear/mcp-server"],
+  "env": {
+    "LINEAR_API_KEY": "lin_api_your_key_here"
+  }
+}
+```
+
+### Step 4 — Verify Both Servers Are Running
+
+```
+Settings -> Connectors -> check "Running" status (green dot)
+```
+
+Both servers must show **"Running"** before use.
+
+### Step 5 — Enable in Chat
+
+```
+Perplexity homepage -> under "Sources" -> toggle ON each connector
+```
+
+---
+
+## REMOTE MCP Setup (coming soon — for trios-mcp server)
+
+When Remote MCP launches, `trios-mcp` deployed on Railway will connect directly:
+
+```json
+{
+  "mcpServers": {
+    "trios-mcp": {
+      "url": "https://trios-mcp.railway.app/sse",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_AUTH_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+This will expose all 13 IGLA RACE tools:
+- `mcp.railway.deploy` — deploy trainer service
+- `mcp.hunt.*` — seed hunter operations
+- `mcp.exp.next` / `mcp.exp.claim` — EXP_ID management
+- `mcp.leaderboard.rank` — BPB leaderboard
+- `mcp.smoke.race` — Gate-0 smoke run
+- `mcp.github.issue` / `mcp.github.pr` — GitHub ops
+
+---
+
+## ALTERNATIVE: Claude Desktop (works today with Remote MCP)
+
+For immediate use with trios-mcp remote server via Claude Desktop:
+
+```json
+// ~/Library/Application Support/Claude/claude_desktop_config.json
+{
+  "mcpServers": {
+    "trios-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/inspector-cli",
+        "https://trios-mcp.railway.app/sse"
+      ],
+      "env": {
+        "MCP_AUTH_BEARER": "your_64_char_token"
+      }
+    },
+    "trios-github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_your_token_here"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing — both servers appear in the tool picker.
+
+---
+
+## Cursor / Continue.dev Config
+
+```json
+// .cursor/mcp.json (repo root)
+{
+  "mcpServers": {
+    "trios-mcp": {
+      "url": "https://trios-mcp.railway.app/sse",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" }
+    },
+    "trios-github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "ghp_your_token" }
+    }
+  }
+}
+```
+
+---
+
+## Testing Checklist
+
+- [ ] PerplexityXPC helper installed
+- [ ] Server 1 (trios-github) shows "Running" in Connectors
+- [ ] Server 2 (trios-linear) shows "Running" in Connectors
+- [ ] Both toggled ON under "Sources"
+- [ ] Test: "Create a GitHub issue in gHashTag/trios"
+- [ ] Test: "List my Linear issues"
+- [ ] Verify tool calls appear in activity log
+
+---
+
+## Where to Get Tokens
+
+| Service | Token Location | Used For |
+|---------|---------------|----------|
+| GitHub | https://github.com/settings/tokens — `repo` scope | trios-github MCP |
+| Linear | https://linear.app/settings/api — Personal API Key | trios-linear MCP |
+| Railway | https://railway.app/account/tokens | trios-mcp server (acc1/acc2/acc3) |
+| Perplexity API | https://www.perplexity.ai/settings/api | Perplexity MCP server |
+
+---
+
+## Related Resources
+
+- [Perplexity MCP Help Center](https://www.perplexity.ai/help-center/en/articles/11502712-local-and-remote-mcps-for-perplexity)
+- [Official Perplexity MCP Server](https://github.com/perplexityai/modelcontextprotocol)
+- [MCP Server Catalog](https://mcp.perplexity.ai/mcp)
+- [trios-mcp Architecture — Issue #333](https://github.com/gHashTag/trios/issues/333)
+- [IGLA RACE Master Rules — Issue #331](https://github.com/gHashTag/trios/issues/331)
+
+---
+
+> **Security note**: Never commit API tokens to the repo. Use env vars or `.env` files in `.gitignore`. All docs and code in this repo must be written **in English**.
+
+> phi^2 + phi^-2 = 3 · TRINITY · MCP-ONLY


### PR DESCRIPTION
## Summary
- **#332**: Add `docs/mcp/MCP_SETUP_GUIDE.md` — complete Perplexity local+remote MCP setup instructions
- **#327**: Add `crates/trios-train-cpu/README.md` — migration status table (M0-M7), Training-Flow V2 plan (P0-P5)
- **#253**: Add missing `RING.md`/`AGENTS.md`/`TASK.md` for UR-04, UR-05, UR-06 + TASK.md for UR-03

12 new files, 420 lines of documentation. No code changes.

Closes #332, Closes #327, Closes #253