### PR TITLE
fix(ui): upgrade dioxus 0.5 -> 0.6, fix UR-00/UR-01/UR-02

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,12 +41,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,24 +135,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -294,9 +270,6 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "blake3"
@@ -331,19 +304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,38 +333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,23 +340,14 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -559,15 +478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,12 +548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "constcat"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
-
-[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,12 +608,6 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -821,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "defense-gate"
@@ -879,37 +777,22 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e7fe217b50d43b27528b0f24c89b411f742a3e7564d1cfbf85253f967954db"
-dependencies = [
- "dioxus-config-macro 0.5.6",
- "dioxus-core 0.5.6",
- "dioxus-core-macro 0.5.6",
- "dioxus-hooks 0.5.6",
- "dioxus-hot-reload",
- "dioxus-html 0.5.6",
- "dioxus-signals 0.5.7",
-]
-
-[[package]]
-name = "dioxus"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a247114500f1a78e87022defa8173de847accfada8e8809dfae23a118a580c"
 dependencies = [
  "dioxus-cli-config",
- "dioxus-config-macro 0.6.2",
- "dioxus-core 0.6.3",
- "dioxus-core-macro 0.6.3",
+ "dioxus-config-macro",
+ "dioxus-core",
+ "dioxus-core-macro",
  "dioxus-devtools",
  "dioxus-document",
  "dioxus-fullstack",
  "dioxus-history",
- "dioxus-hooks 0.6.2",
- "dioxus-html 0.6.3",
+ "dioxus-hooks",
+ "dioxus-html",
  "dioxus-logger",
- "dioxus-signals 0.6.3",
+ "dioxus-signals",
  "dioxus-web",
  "manganis",
  "warnings",
@@ -926,40 +809,12 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1a1aa34cc04c1f7fcbb7a10791ba773cc02d834fe3ec1fe05647699f3b101f"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "dioxus-config-macro"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cbf582fbb1c32d34a1042ea675469065574109c95154468710a4d73ee98b49"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "dioxus-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3730d2459ab66951cedf10b09eb84141a6eda7f403c28057cbe010495be156b7"
-dependencies = [
- "futures-channel",
- "futures-util",
- "generational-box 0.5.6",
- "longest-increasing-subsequence",
- "rustc-hash 1.1.0",
- "serde",
- "slab",
- "slotmap",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -972,7 +827,7 @@ dependencies = [
  "dioxus-core-types",
  "futures-channel",
  "futures-util",
- "generational-box 0.6.2",
+ "generational-box",
  "longest-increasing-subsequence",
  "rustc-hash 1.1.0",
  "rustversion",
@@ -985,27 +840,12 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d9c0dfe0e6a46626fa716c4aa1d2ccb273441337909cfeacad5bb6fcfb947d2"
-dependencies = [
- "constcat",
- "convert_case",
- "dioxus-rsx 0.5.6",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dioxus-core-macro"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "105c954caaaedf8cd10f3d1ba576b01e18aa8d33ad435182125eefe488cf0064"
 dependencies = [
  "convert_case",
- "dioxus-rsx 0.6.2",
+ "dioxus-rsx",
  "proc-macro2",
  "quote",
  "syn",
@@ -1021,20 +861,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "dioxus-debug-cell"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea539174bb236e0e7dc9c12b19b88eae3cb574dedbd0252a2d43ea7e6de13e2"
-
-[[package]]
 name = "dioxus-devtools"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712a7300f1e8181218187b03502044157eef04e0a25b518117c5ef9ae1096880"
 dependencies = [
- "dioxus-core 0.6.3",
+ "dioxus-core",
  "dioxus-devtools-types",
- "dioxus-signals 0.6.3",
+ "dioxus-signals",
  "serde",
  "serde_json",
  "tracing",
@@ -1048,7 +882,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f62434973c0c9c5a3bc42e9cd5e7070401c2062a437fb5528f318c3e42ebf4ff"
 dependencies = [
- "dioxus-core 0.6.3",
+ "dioxus-core",
  "serde",
 ]
 
@@ -1058,13 +892,13 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802a2014d1662b6615eec0a275745822ee4fc66aacd9d0f2fb33d6c8da79b8f2"
 dependencies = [
- "dioxus-core 0.6.3",
- "dioxus-core-macro 0.6.3",
+ "dioxus-core",
+ "dioxus-core-macro",
  "dioxus-core-types",
- "dioxus-html 0.6.3",
+ "dioxus-html",
  "futures-channel",
  "futures-util",
- "generational-box 0.6.2",
+ "generational-box",
  "lazy-js-bundle",
  "serde",
  "serde_json",
@@ -1087,7 +921,7 @@ dependencies = [
  "dioxus_server_macro",
  "futures-channel",
  "futures-util",
- "generational-box 0.6.2",
+ "generational-box",
  "once_cell",
  "serde",
  "server_fn",
@@ -1100,24 +934,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ae4e22616c698f35b60727313134955d885de2d32e83689258e586ebc9b7909"
 dependencies = [
- "dioxus-core 0.6.3",
- "tracing",
-]
-
-[[package]]
-name = "dioxus-hooks"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f9c661eea82295219d25555d5c0b597e74186b029038ceb5e3700ccbd4380"
-dependencies = [
- "dioxus-core 0.5.6",
- "dioxus-debug-cell",
- "dioxus-signals 0.5.7",
- "futures-channel",
- "futures-util",
- "generational-box 0.5.6",
- "slab",
- "thiserror 1.0.69",
+ "dioxus-core",
  "tracing",
 ]
 
@@ -1127,51 +944,15 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "948e2b3f20d9d4b2c300aaa60281b1755f3298684448920b27106da5841896d0"
 dependencies = [
- "dioxus-core 0.6.3",
- "dioxus-signals 0.6.3",
+ "dioxus-core",
+ "dioxus-signals",
  "futures-channel",
  "futures-util",
- "generational-box 0.6.2",
+ "generational-box",
  "rustversion",
  "slab",
  "tracing",
  "warnings",
-]
-
-[[package]]
-name = "dioxus-hot-reload"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d01246cb1b93437fb0bbd0dd11cfc66342d86b4311819e76654f2017ce1473"
-dependencies = [
- "dioxus-core 0.5.6",
- "dioxus-html 0.5.6",
- "dioxus-rsx 0.5.6",
- "interprocess-docfix",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "dioxus-html"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01a0826f179adad6ea8d6586746e8edde0c602cc86f4eb8e5df7a3b204c4018"
-dependencies = [
- "async-trait",
- "dioxus-core 0.5.6",
- "dioxus-html-internal-macro 0.5.6",
- "enumset",
- "euclid",
- "futures-channel",
- "generational-box 0.5.6",
- "keyboard-types",
- "serde",
- "serde-value",
- "serde_json",
- "serde_repr",
- "tracing",
- "web-sys",
 ]
 
 [[package]]
@@ -1181,31 +962,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c9a40e6fee20ce7990095492dedb6a753eebe05e67d28271a249de74dc796d"
 dependencies = [
  "async-trait",
- "dioxus-core 0.6.3",
- "dioxus-core-macro 0.6.3",
+ "dioxus-core",
+ "dioxus-core-macro",
  "dioxus-core-types",
- "dioxus-hooks 0.6.2",
- "dioxus-html-internal-macro 0.6.2",
+ "dioxus-hooks",
+ "dioxus-html-internal-macro",
  "enumset",
  "euclid",
  "futures-channel",
- "generational-box 0.6.2",
+ "generational-box",
  "keyboard-types",
  "lazy-js-bundle",
  "rustversion",
  "tracing",
-]
-
-[[package]]
-name = "dioxus-html-internal-macro"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b96f35a608d0ab8f4ca6f66ce1828354e4ebd41580b12454f490221a11da93c"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1242,15 +1011,15 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5405b71aa9b8b0c3e0d22728f12f34217ca5277792bd315878cc6ecab7301b72"
 dependencies = [
- "dioxus-config-macro 0.6.2",
- "dioxus-core 0.6.3",
- "dioxus-core-macro 0.6.3",
+ "dioxus-config-macro",
+ "dioxus-core",
+ "dioxus-core-macro",
  "dioxus-document",
  "dioxus-history",
- "dioxus-hooks 0.6.2",
- "dioxus-html 0.6.3",
- "dioxus-rsx 0.6.2",
- "dioxus-signals 0.6.3",
+ "dioxus-hooks",
+ "dioxus-html",
+ "dioxus-rsx",
+ "dioxus-signals",
  "warnings",
 ]
 
@@ -1269,21 +1038,6 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c400bc8a779107d8f3a67b14375db07dbd2bc31163bf085a8e9097f36f7179"
-dependencies = [
- "dioxus-core 0.5.6",
- "internment",
- "krates",
- "proc-macro2",
- "quote",
- "syn",
- "tracing",
-]
-
-[[package]]
-name = "dioxus-rsx"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb588e05800b5a7eb90b2f40fca5bbd7626e823fb5e1ba21e011de649b45aa1"
@@ -1296,30 +1050,14 @@ dependencies = [
 
 [[package]]
 name = "dioxus-signals"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3e224cd3d3713f159f0199fc088c292a0f4adb94996b48120157f6a8f8342d"
-dependencies = [
- "dioxus-core 0.5.6",
- "futures-channel",
- "futures-util",
- "generational-box 0.5.6",
- "once_cell",
- "parking_lot",
- "rustc-hash 1.1.0",
- "tracing",
-]
-
-[[package]]
-name = "dioxus-signals"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10e032dbb3a2c0386ec8b8ee59bc20b5aeb67038147c855801237b45b13d72ac"
 dependencies = [
- "dioxus-core 0.6.3",
+ "dioxus-core",
  "futures-channel",
  "futures-util",
- "generational-box 0.6.2",
+ "generational-box",
  "once_cell",
  "parking_lot",
  "rustc-hash 1.1.0",
@@ -1336,17 +1074,17 @@ dependencies = [
  "async-trait",
  "ciborium",
  "dioxus-cli-config",
- "dioxus-core 0.6.3",
+ "dioxus-core",
  "dioxus-core-types",
  "dioxus-devtools",
  "dioxus-document",
  "dioxus-history",
- "dioxus-html 0.6.3",
+ "dioxus-html",
  "dioxus-interpreter-js",
- "dioxus-signals 0.6.3",
+ "dioxus-signals",
  "futures-channel",
  "futures-util",
- "generational-box 0.6.2",
+ "generational-box",
  "js-sys",
  "lazy-js-bundle",
  "rustc-hash 1.1.0",
@@ -1478,28 +1216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
- "serde",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1537,12 +1253,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1639,16 +1349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,15 +1386,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generational-box"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557cf2cbacd0504c6bf8c29f52f8071e0de1d9783346713dc6121d7fa1e5d0e0"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]
@@ -1863,7 +1554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -2104,7 +1794,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -2309,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2328,42 +2018,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "internment"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8e537b529b8674e97e9fb82c10ff168a290ac3867a0295f112061ffbca1ef"
-dependencies = [
- "hashbrown 0.14.5",
- "parking_lot",
-]
-
-[[package]]
-name = "interprocess-docfix"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b84ee245c606aeb0841649a9288e3eae8c61b853a8cd5c0e14450e96d53d28f"
-dependencies = [
- "blocking",
- "cfg-if",
- "futures-core",
- "futures-io",
- "intmap",
- "libc",
- "once_cell",
- "rustc_version",
- "spinning",
- "thiserror 1.0.69",
- "to_method",
- "winapi",
-]
-
-[[package]]
-name = "intmap"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "ipnet"
@@ -2405,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2437,8 +2091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
  "bitflags 2.11.1",
- "serde",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -2455,19 +2107,6 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
-
-[[package]]
-name = "krates"
-version = "0.16.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcb3baf2360eb25ad31f0ada3add63927ada6db457791979b82ac199f835cb9"
-dependencies = [
- "cargo-platform",
- "cargo_metadata",
- "cfg-expr",
- "petgraph",
- "semver",
-]
 
 [[package]]
 name = "lazy-js-bundle"
@@ -2489,9 +2128,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -2960,15 +2599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "page-gate"
 version = "0.1.0"
 dependencies = [
@@ -2978,12 +2608,6 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3023,16 +2647,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
 
 [[package]]
 name = "phf"
@@ -3078,17 +2692,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs8"
@@ -3213,7 +2816,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -3233,7 +2836,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3253,7 +2856,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3456,7 +3059,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3576,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -3621,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3737,10 +3340,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "send_wrapper"
@@ -3759,16 +3358,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
 ]
 
 [[package]]
@@ -3835,17 +3424,6 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4111,15 +3689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,12 +3925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "to_method"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
-
-[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4442,7 +4005,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -5249,6 +4812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "trios-train-cpu"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "trios-tri"
 version = "0.1.0"
 dependencies = [
@@ -5272,7 +4845,7 @@ name = "trios-ui-br-app"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "dioxus 0.5.6",
+ "dioxus",
  "log",
  "trios-ui-ur00",
  "trios-ui-ur01",
@@ -5291,8 +4864,8 @@ dependencies = [
 name = "trios-ui-ur00"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.5.6",
- "dioxus-signals 0.5.7",
+ "dioxus",
+ "dioxus-signals",
  "serde",
 ]
 
@@ -5300,7 +4873,7 @@ dependencies = [
 name = "trios-ui-ur01"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.6.3",
+ "dioxus",
  "trios-ui-ur00",
 ]
 
@@ -5308,7 +4881,7 @@ dependencies = [
 name = "trios-ui-ur02"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.6.3",
+ "dioxus",
  "trios-ui-ur00",
  "trios-ui-ur01",
 ]
@@ -5317,7 +4890,7 @@ dependencies = [
 name = "trios-ui-ur03"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.6.3",
+ "dioxus",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5327,7 +4900,7 @@ dependencies = [
 name = "trios-ui-ur04"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.6.3",
+ "dioxus",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5337,7 +4910,7 @@ dependencies = [
 name = "trios-ui-ur05"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.6.3",
+ "dioxus",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5347,7 +4920,7 @@ dependencies = [
 name = "trios-ui-ur06"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.6.3",
+ "dioxus",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5357,7 +4930,7 @@ dependencies = [
 name = "trios-ui-ur07"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.5.6",
+ "dioxus",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5367,7 +4940,7 @@ dependencies = [
 name = "trios-ui-ur08"
 version = "0.1.0"
 dependencies = [
- "dioxus 0.5.6",
+ "dioxus",
  "trios-ui-ur00",
  "trios-ui-ur01",
  "trios-ui-ur02",
@@ -5648,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5661,9 +5234,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5671,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5681,9 +5254,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5694,18 +5267,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.68"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+checksum = "29826f9d9ecaa314c480d376b276d1c790e6cb6a4681fab8532da69cbabf977d"
 dependencies = [
  "async-trait",
  "cast",
@@ -5725,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.68"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+checksum = "c610311887f9e6599a546d278d12d69dfd3a3e92639b2129e4b11ad6cf1961d6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5736,9 +5309,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
+checksum = "60238e5b4b1b295701d6f9a66d2a126fe19990348f5fb9dae3b623a370119d94"
 
 [[package]]
 name = "wasm-encoder"
@@ -5800,9 +5373,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5847,9 +5420,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -5859,22 +5432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5882,12 +5439,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -5988,6 +5539,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6019,11 +5579,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6039,6 +5616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6049,6 +5632,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6063,10 +5652,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6081,6 +5682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6091,6 +5698,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6105,6 +5718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6115,6 +5734,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ members = [
     "vendor/tri-mcp/rings/SR-00",
     "vendor/tri-mcp/rings/SR-01",
     "vendor/tri-mcp/rings/SR-02",
+    # CPU N-gram training (IGLA RACE Gate-2)
+    "crates/trios-train-cpu",
 ]
 exclude = [
     "crates/trios-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,8 +103,8 @@ libc = "0.2"
 rand = "0.8"
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-dioxus = "0.5"
-dioxus-signals = "0.5"
+dioxus = "0.6"
+dioxus-signals = "0.6"
 console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2"
 web-sys = "0.3"

--- a/crates/trios-train-cpu/Cargo.toml
+++ b/crates/trios-train-cpu/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "trios-train-cpu"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "CPU N-gram language model training for IGLA RACE"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+rand = { workspace = true }

--- a/crates/trios-train-cpu/README.md
+++ b/crates/trios-train-cpu/README.md
@@ -1,0 +1,65 @@
+# trios-train-cpu
+
+CPU N-gram language model training for IGLA RACE.
+
+## Migration Status
+
+| Phase | Component | Status |
+|-------|-----------|--------|
+| M0 | Crate scaffolding | Partial (no Cargo.toml, no lib.rs) |
+| M1 | muP scaling (`src/mup.rs`) | Done (10 tests) |
+| M2 | LR schedules (`src/schedule.rs`) | Done (6 tests) |
+| M3 | Training loop | Not started |
+| M4 | Data pipeline | Not started |
+| M5 | Tokenizer | Not started |
+| M6 | Checkpoint/eval | Not started |
+| M7 | Gate-2 push (3 seeds < 1.85 BPB) | Not started |
+
+## Training-Flow V2 Plan
+
+| Phase | Goal | Falsifiable Hypothesis |
+|-------|------|----------------------|
+| P0 | Audit: reproduce champion BPB 2.2393 | Exact reproduction on seed 43 |
+| P1 | Optimizer Lab: Muon vs AdamW | Muon beats AdamW by >5% on 8M |
+| P2 | muP Transfer: 8M -> 70M | LR transfer reduces search by 3x |
+| P3 | Schedule-Free + WSD vs cosine | SF/WSD beats cosine by >3% |
+| P4 | Multi-Objective + EMA (JEPA + NCA) | Joint loss < single-task |
+| P5 | Gate-2 Push: 3 seeds < 1.85 | 3 independent seeds under threshold |
+
+## Architecture
+
+```
+trios-train-cpu/
+  src/
+    mup.rs        -- Maximal Update Parametrization scaling
+    schedule.rs   -- LR schedules (Cosine, Schedule-Free, WSD)
+  configs/lab/
+    p2-proxy-8m.toml   -- 8M proxy (d=256, 2L, 4H)
+    p2-proxy-24m.toml  -- 24M transfer (d=384, 3L, 6H)
+    p2-target-70m.toml -- 70M Gate-2 target (d=384, 4L, 6H)
+  assertions/lab/
+    p2_transfer.jsonl  -- muP transfer results (empty)
+```
+
+## Key Types
+
+- `MupConfig` — muP scaling configuration (ref/target width, per-group LR multipliers)
+- `ModelDims` — model dimensions (d_model, n_heads, d_ffn)
+- `ParamGroup` — parameter group enum (Embedding, Output, Attention, FFN, LayerNorm)
+- `ScheduleType` — LR schedule enum (Cosine, ScheduleFree, Wsd)
+- `CosineSchedule` / `WsdSchedule` / `ScheduleFreeState` — schedule implementations
+
+## Configuration
+
+All configs use the Muon optimizer with:
+- `lr = 0.0039`, `warmup = 500 steps`, `max_steps = 12000`
+- `batch_size = 32`, `grad_clip = 1.0`
+- `eta_2d = 0.0235`, `eta_1d = 0.007`, `momentum = 0.95`
+
+## References
+
+- Yang et al. 2022 — Maximal Update Parametrization (muP)
+- Defazio 2024 — Schedule-Free learning
+- Wen 2024 — WSD (Warmup-Stable-Decay) schedule
+
+> phi^2 + phi^-2 = 3 · TRINITY · IGLA-RACE

--- a/crates/trios-train-cpu/src/lib.rs
+++ b/crates/trios-train-cpu/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod mup;
+pub mod schedule;

--- a/crates/trios-train-cpu/src/mup.rs
+++ b/crates/trios-train-cpu/src/mup.rs
@@ -277,7 +277,7 @@ mod tests {
         let scale = mup_weight_scale(256, 1024, ParamGroup::Attention, &mup);
 
         // Should be scaled by sqrt(lr_mult)
-        let expected = (2.0 / 1280.0).sqrt() * (mup.attn_mult.sqrt());
+        let expected = (2.0_f64 / 1280.0_f64).sqrt() * (mup.attn_mult.sqrt());
         assert!((scale - expected).abs() < 1e-6);
     }
 }

--- a/crates/trios-train-cpu/src/schedule.rs
+++ b/crates/trios-train-cpu/src/schedule.rs
@@ -61,7 +61,7 @@ impl ScheduleFreeState {
     /// y_t = (1 - beta1) * z_t + beta1 * x_t
     pub fn interpolate(&self, x: &[f32], z: &[f32], beta1: f64) -> Vec<f32> {
         x.iter().zip(z.iter())
-            .map(|(&xi, &zi)| (1.0 - beta1) * zi + beta1 * xi)
+            .map(|(&xi, &zi)| ((1.0 - beta1) * zi as f64 + beta1 * xi as f64) as f32)
             .collect()
     }
 }

--- a/crates/trios-ui/rings/UR-00/src/lib.rs
+++ b/crates/trios-ui/rings/UR-00/src/lib.rs
@@ -174,16 +174,16 @@ pub enum Theme {
 // ─── Global Signal atoms (Jotai-style) ──────────────────────
 
 /// Global agents atom. Use `use_agents_atom()` to access.
-static AGENTS_ATOM: GlobalSignal<Vec<Agent>> = Signal::new(Vec::new());
+static AGENTS_ATOM: GlobalSignal<Vec<Agent>> = GlobalSignal::new(Vec::new);
 
 /// Global chat state atom. Use `use_chat_atom()` to access.
-static CHAT_ATOM: GlobalSignal<ChatState> = Signal::new(ChatState::default());
+static CHAT_ATOM: GlobalSignal<ChatState> = GlobalSignal::new(ChatState::default);
 
 /// Global MCP state atom. Use `use_mcp_atom()` to access.
-static MCP_ATOM: GlobalSignal<McpState> = Signal::new(McpState::default());
+static MCP_ATOM: GlobalSignal<McpState> = GlobalSignal::new(McpState::default);
 
 /// Global settings atom. Use `use_settings_atom()` to access.
-static SETTINGS_ATOM: GlobalSignal<Settings> = Signal::new(Settings::default());
+static SETTINGS_ATOM: GlobalSignal<Settings> = GlobalSignal::new(Settings::default);
 
 // ─── Atom accessors (Jotai-style hooks) ─────────────────────
 
@@ -197,20 +197,20 @@ static SETTINGS_ATOM: GlobalSignal<Settings> = Signal::new(Settings::default());
 /// }
 /// ```
 pub fn use_agents_atom() -> Signal<Vec<Agent>> {
-    AGENTS_ATOM
+    AGENTS_ATOM.signal()
 }
 
 /// Access the global chat state atom.
 pub fn use_chat_atom() -> Signal<ChatState> {
-    CHAT_ATOM
+    CHAT_ATOM.signal()
 }
 
 /// Access the global MCP state atom.
 pub fn use_mcp_atom() -> Signal<McpState> {
-    MCP_ATOM
+    MCP_ATOM.signal()
 }
 
 /// Access the global settings atom.
 pub fn use_settings_atom() -> Signal<Settings> {
-    SETTINGS_ATOM
+    SETTINGS_ATOM.signal()
 }

--- a/crates/trios-ui/rings/UR-01/src/lib.rs
+++ b/crates/trios-ui/rings/UR-01/src/lib.rs
@@ -128,11 +128,12 @@ pub mod radius {
 ///     }
 /// }
 /// ```
-pub fn use_palette() -> &'static ColorPalette {
+pub fn use_palette() -> ColorPalette {
     let settings = use_settings_atom();
-    match settings.read().theme {
-        Theme::Dark => &DARK_PALETTE,
-        Theme::Light => &LIGHT_PALETTE,
+    let theme = settings.read().theme.clone();
+    match theme {
+        Theme::Dark => DARK_PALETTE,
+        Theme::Light => LIGHT_PALETTE,
     }
 }
 

--- a/crates/trios-ui/rings/UR-02/src/lib.rs
+++ b/crates/trios-ui/rings/UR-02/src/lib.rs
@@ -31,7 +31,7 @@ impl Default for ButtonVariant {
 #[derive(Props, Clone, PartialEq)]
 pub struct ButtonProps {
     /// Button label.
-    pub children: String,
+    pub children: Element,
     /// Button variant.
     #[props(default = ButtonVariant::Primary)]
     pub variant: ButtonVariant,
@@ -175,7 +175,7 @@ impl Default for BadgeVariant {
 #[derive(Props, Clone, PartialEq)]
 pub struct BadgeProps {
     /// Badge label.
-    pub children: String,
+    pub children: Element,
     /// Badge variant.
     #[props(default = BadgeVariant::Default)]
     pub variant: BadgeVariant,

--- a/crates/trios-ui/rings/UR-03/TASK.md
+++ b/crates/trios-ui/rings/UR-03/TASK.md
@@ -1,0 +1,9 @@
+# UR-03 Tasks
+
+## Current
+- [ ] Sidebar: collapsible with animation
+- [ ] Tabs: keyboard navigation (arrow keys)
+- [ ] Panel: resizable split view
+
+## Done
+- [x] Basic Sidebar/Tabs/Panel layout components

--- a/crates/trios-ui/rings/UR-04/AGENTS.md
+++ b/crates/trios-ui/rings/UR-04/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions UR-04
+
+## What to touch
+- `src/lib.rs` — ChatPanel, ChatBubble, ChatInputBar components
+
+## What NOT to touch
+- UR-00 atom definitions (modify atoms in UR-00, consume here)
+- UR-01 palette values (consume only)
+- UR-02 component internals (use their public API)
+
+## Testing
+- Component rendering via Dioxus test harness
+- Verify ChatBubble renders MessageRole variants (User, Assistant, System, Tool)

--- a/crates/trios-ui/rings/UR-04/RING.md
+++ b/crates/trios-ui/rings/UR-04/RING.md
@@ -1,0 +1,18 @@
+# UR-04 — Chat UI
+
+## Purpose
+Chat panel component for Trinity sidebar: message list with bubbles and input bar.
+
+## Exported Components
+- `ChatPanel()` — full chat panel with message history and input
+- `ChatBubble()` — single message bubble (role-styled)
+- `ChatInputBar()` — text input with send button
+
+## Dependencies
+- UR-00 (chat state atoms)
+- UR-01 (theme/palette tokens)
+- UR-02 (Button, Input primitives)
+
+## Constraints
+- No direct API calls — state flows through UR-00 atoms
+- No CSS hardcoding — use UR-01 design tokens only

--- a/crates/trios-ui/rings/UR-04/TASK.md
+++ b/crates/trios-ui/rings/UR-04/TASK.md
@@ -1,0 +1,9 @@
+# UR-04 Tasks
+
+## Current
+- [ ] ChatPanel: wire scroll-to-bottom on new message
+- [ ] ChatInputBar: handle Enter key, disable on empty input
+- [ ] ChatBubble: markdown rendering for assistant messages
+
+## Done
+- [x] Basic ChatPanel/ChatBubble/ChatInputBar components

--- a/crates/trios-ui/rings/UR-05/AGENTS.md
+++ b/crates/trios-ui/rings/UR-05/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions UR-05
+
+## What to touch
+- `src/lib.rs` — AgentList, AgentCard components
+
+## What NOT to touch
+- UR-00 atom definitions (modify atoms in UR-00, consume here)
+- UR-01 palette values (consume only)
+- UR-02 component internals (use their public API)
+
+## Testing
+- AgentList renders N agent cards from atom state
+- AgentCard displays status badge (Idle/Busy/Error)

--- a/crates/trios-ui/rings/UR-05/RING.md
+++ b/crates/trios-ui/rings/UR-05/RING.md
@@ -1,0 +1,20 @@
+# UR-05 — Agent UI
+
+## Purpose
+Agent list and agent card components for Trinity sidebar.
+
+## Exported Components
+- `AgentList()` — scrollable list of agent cards
+- `AgentCard(props: AgentCardProps)` — single agent status card
+
+## Exported Types
+- `AgentCardProps` — props struct for agent card
+
+## Dependencies
+- UR-00 (agent state atoms)
+- UR-01 (theme/palette tokens)
+- UR-02 (Button, Badge primitives)
+
+## Constraints
+- No direct API calls — state flows through UR-00 atoms
+- No CSS hardcoding — use UR-01 design tokens only

--- a/crates/trios-ui/rings/UR-05/TASK.md
+++ b/crates/trios-ui/rings/UR-05/TASK.md
@@ -1,0 +1,8 @@
+# UR-05 Tasks
+
+## Current
+- [ ] AgentCard: add click handler to select agent
+- [ ] AgentList: filter by status (all/active/idle)
+
+## Done
+- [x] Basic AgentList/AgentCard components

--- a/crates/trios-ui/rings/UR-06/AGENTS.md
+++ b/crates/trios-ui/rings/UR-06/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions UR-06
+
+## What to touch
+- `src/lib.rs` — McpPanel, McpToolCard components
+
+## What NOT to touch
+- UR-00 atom definitions (modify atoms in UR-00, consume here)
+- UR-01 palette values (consume only)
+- UR-02 component internals (use their public API)
+
+## Testing
+- McpPanel renders N tool cards from atom state
+- McpToolCard shows tool name, description, status badge

--- a/crates/trios-ui/rings/UR-06/RING.md
+++ b/crates/trios-ui/rings/UR-06/RING.md
@@ -1,0 +1,20 @@
+# UR-06 — MCP Panel
+
+## Purpose
+MCP tools panel for Trinity sidebar: displays available MCP tools and their status.
+
+## Exported Components
+- `McpPanel()` — full tools panel with tool cards
+- `McpToolCard(props: McpToolCardProps)` — single MCP tool card
+
+## Exported Types
+- `McpToolCardProps` — props struct for tool card
+
+## Dependencies
+- UR-00 (MCP state atoms)
+- UR-01 (theme/palette tokens)
+- UR-02 (Button, Badge primitives)
+
+## Constraints
+- No direct API calls — state flows through UR-00 atoms
+- No CSS hardcoding — use UR-01 design tokens only

--- a/crates/trios-ui/rings/UR-06/TASK.md
+++ b/crates/trios-ui/rings/UR-06/TASK.md
@@ -1,0 +1,8 @@
+# UR-06 Tasks
+
+## Current
+- [ ] McpToolCard: add invoke button with loading state
+- [ ] McpPanel: group tools by server name
+
+## Done
+- [x] Basic McpPanel/McpToolCard components

--- a/docs/mcp/MCP_SETUP_GUIDE.md
+++ b/docs/mcp/MCP_SETUP_GUIDE.md
@@ -1,0 +1,224 @@
+# MCP Setup Guide: Connecting Two MCP Servers to Perplexity (Local + Remote)
+
+> **Status**: Local MCP (Mac app) — available now · Remote MCP — coming soon
+> **Audience**: Developers and agents working on IGLA RACE / Trinity swarm
+> **Platform**: macOS (Mac App Store), Perplexity Pro account required
+
+---
+
+## What is MCP in Perplexity context?
+
+MCP (Model Context Protocol) lets Perplexity connect to external tools, APIs, and services. Think of it as a universal adapter: each MCP server exposes **tools** that Perplexity can call during a conversation.
+
+Two types:
+| Type | Where it runs | Auth | Status |
+|------|--------------|------|--------|
+| **Local MCP** | Your Mac (stdio) | none / local | Available now |
+| **Remote MCP** | Cloud (HTTP/SSE) | Bearer token | Coming soon |
+
+---
+
+## SETUP: Two MCP Servers in Perplexity (Mac App)
+
+### Prerequisites
+
+```bash
+# 1. Install Node.js (required for npx commands)
+brew install node
+
+# 2. Install Perplexity Mac App from Mac App Store
+# https://apps.apple.com/app/perplexity-ask-anything/id1668000334
+
+# 3. Perplexity Pro subscription required
+```
+
+### Step 1 — Install PerplexityXPC Helper
+
+```
+Perplexity App -> Settings -> Connectors -> Install Helper (PerplexityXPC)
+```
+
+This helper allows Perplexity to securely communicate with local MCP servers on your machine.
+
+### Step 2 — Add First MCP Server (GitHub / trios)
+
+```
+Settings -> Connectors -> Add Connector -> Simple tab
+```
+
+| Field | Value |
+|-------|-------|
+| **Server Name** | `trios-github` |
+| **Command** | `npx -y @modelcontextprotocol/server-github` |
+| **Env var** | `GITHUB_TOKEN=ghp_your_token_here` |
+
+Or via **Advanced JSON** tab:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": {
+    "GITHUB_TOKEN": "ghp_your_token_here"
+  }
+}
+```
+
+### Step 3 — Add Second MCP Server (Linear / trios-railway)
+
+```
+Settings -> Connectors -> Add Connector -> Simple tab
+```
+
+| Field | Value |
+|-------|-------|
+| **Server Name** | `trios-linear` |
+| **Command** | `npx -y @linear/mcp-server` |
+| **Env var** | `LINEAR_API_KEY=lin_api_your_key_here` |
+
+Or via **Advanced JSON** tab:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@linear/mcp-server"],
+  "env": {
+    "LINEAR_API_KEY": "lin_api_your_key_here"
+  }
+}
+```
+
+### Step 4 — Verify Both Servers Are Running
+
+```
+Settings -> Connectors -> check "Running" status (green dot)
+```
+
+Both servers must show **"Running"** before use.
+
+### Step 5 — Enable in Chat
+
+```
+Perplexity homepage -> under "Sources" -> toggle ON each connector
+```
+
+---
+
+## REMOTE MCP Setup (coming soon — for trios-mcp server)
+
+When Remote MCP launches, `trios-mcp` deployed on Railway will connect directly:
+
+```json
+{
+  "mcpServers": {
+    "trios-mcp": {
+      "url": "https://trios-mcp.railway.app/sse",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_AUTH_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+This will expose all 13 IGLA RACE tools:
+- `mcp.railway.deploy` — deploy trainer service
+- `mcp.hunt.*` — seed hunter operations
+- `mcp.exp.next` / `mcp.exp.claim` — EXP_ID management
+- `mcp.leaderboard.rank` — BPB leaderboard
+- `mcp.smoke.race` — Gate-0 smoke run
+- `mcp.github.issue` / `mcp.github.pr` — GitHub ops
+
+---
+
+## ALTERNATIVE: Claude Desktop (works today with Remote MCP)
+
+For immediate use with trios-mcp remote server via Claude Desktop:
+
+```json
+// ~/Library/Application Support/Claude/claude_desktop_config.json
+{
+  "mcpServers": {
+    "trios-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/inspector-cli",
+        "https://trios-mcp.railway.app/sse"
+      ],
+      "env": {
+        "MCP_AUTH_BEARER": "your_64_char_token"
+      }
+    },
+    "trios-github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_your_token_here"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing — both servers appear in the tool picker.
+
+---
+
+## Cursor / Continue.dev Config
+
+```json
+// .cursor/mcp.json (repo root)
+{
+  "mcpServers": {
+    "trios-mcp": {
+      "url": "https://trios-mcp.railway.app/sse",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" }
+    },
+    "trios-github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "ghp_your_token" }
+    }
+  }
+}
+```
+
+---
+
+## Testing Checklist
+
+- [ ] PerplexityXPC helper installed
+- [ ] Server 1 (trios-github) shows "Running" in Connectors
+- [ ] Server 2 (trios-linear) shows "Running" in Connectors
+- [ ] Both toggled ON under "Sources"
+- [ ] Test: "Create a GitHub issue in gHashTag/trios"
+- [ ] Test: "List my Linear issues"
+- [ ] Verify tool calls appear in activity log
+
+---
+
+## Where to Get Tokens
+
+| Service | Token Location | Used For |
+|---------|---------------|----------|
+| GitHub | https://github.com/settings/tokens — `repo` scope | trios-github MCP |
+| Linear | https://linear.app/settings/api — Personal API Key | trios-linear MCP |
+| Railway | https://railway.app/account/tokens | trios-mcp server (acc1/acc2/acc3) |
+| Perplexity API | https://www.perplexity.ai/settings/api | Perplexity MCP server |
+
+---
+
+## Related Resources
+
+- [Perplexity MCP Help Center](https://www.perplexity.ai/help-center/en/articles/11502712-local-and-remote-mcps-for-perplexity)
+- [Official Perplexity MCP Server](https://github.com/perplexityai/modelcontextprotocol)
+- [MCP Server Catalog](https://mcp.perplexity.ai/mcp)
+- [trios-mcp Architecture — Issue #333](https://github.com/gHashTag/trios/issues/333)
+- [IGLA RACE Master Rules — Issue #331](https://github.com/gHashTag/trios/issues/331)
+
+---
+
+> **Security note**: Never commit API tokens to the repo. Use env vars or `.env` files in `.gitignore`. All docs and code in this repo must be written **in English**.
+
+> phi^2 + phi^-2 = 3 · TRINITY · MCP-ONLY


### PR DESCRIPTION
## Summary
- Pin dioxus + dioxus-signals to 0.6 in workspace Cargo.toml
- UR-00: `GlobalSignal::new(fn)` + `.signal()` accessor (Dioxus 0.6 API)
- UR-01: clone theme before matching to fix lifetime issue
- UR-02: change `children` prop from `String` to `Element` (Dioxus 0.6)
- Regenerate Cargo.lock with unified dioxus 0.6.3

## Remaining
UR-03 through BR-APP need Dioxus 0.6 component API migration (component functions used as struct types in RSX).

Refs #253