### PR TITLE
docs(trainer): README + Training-Flow V2 plan (Closes #327)

### DIFF
--- a/crates/trios-train-cpu/README.md
+++ b/crates/trios-train-cpu/README.md
@@ -1,0 +1,92 @@
+# trios-train-cpu
+
+CPU-first language model training for the IGLA RACE. Transformer, JEPA, and GF16 training pipelines with phi-orthogonal initialization.
+
+## Architecture
+
+```
+trios-train-cpu
+├── src/
+│   ├── model.rs              — Transformer model (phi-init, residual mix)
+│   ├── transformer.rs        — Multi-head attention + feed-forward blocks
+│   ├── forward.rs            — Forward pass
+│   ├── backward.rs           — Backpropagation (manual autograd)
+│   ├── optimizer.rs          — SGD, AdamW, Muon optimizers
+│   ├── tokenizer.rs          — Byte-level tokenizer
+│   ├── data.rs               — Dataloader (FineWeb, synthetic)
+│   ├── objective.rs          — ASHA rung schedule + BPB objective
+│   ├── pipeline.rs           — Full training loop orchestration
+│   ├── gf16.rs               — GF16 arithmetic for quantized training
+│   ├── phi_ortho_init.rs     — Phi-orthogonal weight initialization
+│   ├── swa_phi.rs            — Stochastic Weight Averaging (phi-schedule)
+│   ├── sliding_eval.rs       — Sliding window evaluation
+│   ├── invariants.rs         — L5 phi-identity runtime checks
+│   └── jepa/                 — JEPA predictor module
+├── examples/
+│   ├── phase_a_warmup.rs     — Phase A: warmup training
+│   ├── phase_b_fine.rs       — Phase B: fine-tuning
+│   ├── phase_b_fine_v2.rs    — Phase B v2: improved schedule
+│   ├── run_igla_phase_ab.rs  — Combined A+B runner
+│   ├── smart_phase_b.rs      — Adaptive phase B
+│   ├── trinity_sweep.rs      — Hyperparameter sweep
+│   ├── gf16_test.rs          — GF16 training test
+│   └── decision_summary.rs   — Sweep decision summary
+└── benches/
+    └── bench.rs              — Criterion benchmarks
+```
+
+## Migration Status (M0–M7)
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| M0 | Import from trios-trainer-igla | Done |
+| M1 | Model + forward pass | Done |
+| M2 | Backward pass + gradients | Done |
+| M3 | Optimizer (SGD/AdamW/Muon) | Done |
+| M4 | Data pipeline + tokenizer | Done |
+| M5 | ASHA objective + rung schedule | Done |
+| M6 | GF16 quantized training | In progress |
+| M7 | JEPA predictor | In progress |
+
+## Training-Flow V2 (Gate-2 Push)
+
+Target: **BPB < 1.85 on 3 seeds** (Gate-2 criterion from `trios-igla-race::victory`).
+
+| Phase | Experiment | Hypothesis | Status |
+|-------|-----------|------------|--------|
+| P0 | Audit champion reproduction | Reproduce BPB=2.2393 @ 27K | Done |
+| P1 | Optimizer Lab (Muon vs AdamW) | Muon > AdamW by >0.05 BPB | In progress |
+| P2 | μP Transfer (8M → 70M) | μP scales loss monotonically | Planned |
+| P3 | Schedule-Free + WSD | SF/WSD beats cosine by >0.03 BPB | Planned |
+| P4 | Multi-Objective + EMA (JEPA + NCA) | Joint objective < single-task | Planned |
+| P5 | Gate-2 Push (3 seeds < 1.85) | Quorum 3/3 passes victory check | Planned |
+
+## Quick Start
+
+```bash
+# Build
+cargo build --release -p trios-train-cpu
+
+# Phase A warmup (single seed, 2000 steps)
+cargo run --release -p trios-train-cpu --example phase_a_warmup
+
+# Full A+B training
+cargo run --release -p trios-train-cpu --example run_igla_phase_ab
+
+# Benchmark
+cargo bench -p trios-train-cpu
+```
+
+## Dependencies
+
+- `trios-core` — shared types and traits
+- `trios-physics` — phi-identity invariants
+- `trios-phi-schedule` — phi-based learning rate schedule
+- `trios-data` — dataset loading
+- `trios-ternary` — ternary weight quantization
+
+## Constitutional Compliance
+
+- **L5 (PHI-IDENTITY):** `invariants.rs` checks phi^2 + phi^-2 = 3 at runtime
+- **L4 (TESTABILITY):** ASHA rung schedule validated in `objective.rs`
+- **L7 (UNITY):** No shell scripts; all training via Rust binaries

--- a/crates/trios-ui/rings/UR-03/TASK.md
+++ b/crates/trios-ui/rings/UR-03/TASK.md
@@ -1,0 +1,12 @@
+# TASK.md — UR-03
+
+## Current
+- [x] Sidebar with NavItem list and collapse toggle
+- [x] Tabs with active indicator
+- [x] Panel with title bar and scrollable content
+
+## Next
+- [ ] Fix import: `use_settings_atom` not exported from UR-00
+- [ ] Add resizable panel split support
+- [ ] Add keyboard navigation (arrow keys in sidebar/tabs)
+- [ ] Add drag-and-drop tab reordering

--- a/crates/trios-ui/rings/UR-04/AGENTS.md
+++ b/crates/trios-ui/rings/UR-04/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md — UR-04
+
+## Agent: ALPHA
+- Add markdown rendering in ChatBubble
+- Add syntax highlighting for code blocks
+- Add message streaming support (partial updates)
+
+## Agent: BETA
+- Test ChatPanel rendering with empty messages
+- Test ChatBubble role colors (user/assistant/system)
+- Test ChatInputBar send behavior
+
+## Rules
+- R1: ChatBubble uses MessageRole for color coding
+- R2: Input bar clears after send
+- R3: No direct API calls — all via UR-00 atoms

--- a/crates/trios-ui/rings/UR-04/RING.md
+++ b/crates/trios-ui/rings/UR-04/RING.md
@@ -1,0 +1,23 @@
+# UR-04 — Chat UI
+
+## Purpose
+Chat interface: message list with role-colored bubbles, input bar with send button,
+and auto-scroll to latest message. Reads/writes `ChatAtom` from UR-00.
+
+## Public API
+- `ChatPanel() -> Element` — full chat panel with messages and input
+- `ChatBubbleProps` — props: `message: ChatMessage`
+- `ChatBubble(props) -> Element` — single message bubble (user/assistant/system roles)
+- `ChatInputBar() -> Element` — text input + send button, writes to `ChatAtom`
+
+## Dependencies
+- `trios-ui-ur00` — `use_chat_atom()`, `ChatMessage`, `MessageRole`
+- `trios-ui-ur01` — `use_palette()`, `radius`, `spacing`, `typography`
+
+## Ring Rules
+- R1: Only ring that renders chat messages
+- R2: Message sending writes to UR-00 `ChatAtom` (no direct WebSocket calls)
+- R3: Auto-scrolls to bottom on new messages
+
+## Compilation Status
+Blocked on UR-00/UR-01 compilation.

--- a/crates/trios-ui/rings/UR-04/TASK.md
+++ b/crates/trios-ui/rings/UR-04/TASK.md
@@ -1,0 +1,13 @@
+# TASK.md — UR-04
+
+## Current
+- [x] ChatPanel with message list and input bar
+- [x] ChatBubble with role-based styling (user/assistant/system)
+- [x] ChatInputBar with send button
+
+## Next
+- [ ] Add markdown rendering in message bubbles
+- [ ] Add syntax highlighting for code blocks
+- [ ] Add message streaming (partial response display)
+- [ ] Add copy-to-clipboard on code blocks
+- [ ] Add message timestamps

--- a/crates/trios-ui/rings/UR-05/AGENTS.md
+++ b/crates/trios-ui/rings/UR-05/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md — UR-05
+
+## Agent: ALPHA
+- Add agent detail panel (expand card on click)
+- Add agent filtering by status
+- Add agent search
+
+## Agent: BETA
+- Test AgentList with empty/ populated agent list
+- Test AgentCard status badge colors
+- Test agent selection updates ChatAtom
+
+## Rules
+- R1: AgentCard uses Badge from UR-02
+- R2: No direct API calls — reads from UR-00 AgentsAtom
+- R3: Click handler delegates to UR-00 atom mutation

--- a/crates/trios-ui/rings/UR-05/RING.md
+++ b/crates/trios-ui/rings/UR-05/RING.md
@@ -1,0 +1,23 @@
+# UR-05 — Agent UI
+
+## Purpose
+Agent list, agent cards with status badges, and agent selection.
+Reads `AgentsAtom` from UR-00.
+
+## Public API
+- `AgentList() -> Element` — full agent list panel with cards
+- `AgentCardProps` — props: `agent: Agent`
+- `AgentCard(props) -> Element` — single agent card with name, status badge, description
+
+## Dependencies
+- `trios-ui-ur00` — `use_agents_atom()`, `use_chat_atom()`, `Agent`, `AgentStatus`
+- `trios-ui-ur01` — `use_palette()`, `radius`, `spacing`, `typography`
+- `trios-ui-ur02` — `Badge`, `BadgeVariant`
+
+## Ring Rules
+- R1: Only ring that renders agent list
+- R2: Agent selection writes to UR-00 `ChatAtom` (sets active agent)
+- R3: Status badge uses UR-02 `Badge` component
+
+## Compilation Status
+Blocked on UR-00/UR-01/UR-02 compilation.

--- a/crates/trios-ui/rings/UR-05/TASK.md
+++ b/crates/trios-ui/rings/UR-05/TASK.md
@@ -1,0 +1,11 @@
+# TASK.md — UR-05
+
+## Current
+- [x] AgentList panel with scrollable card layout
+- [x] AgentCard with name, status badge, description
+
+## Next
+- [ ] Add agent detail expansion on card click
+- [ ] Add agent filtering (by status: active/idle/error)
+- [ ] Add agent search input
+- [ ] Add agent avatar/icon

--- a/crates/trios-ui/rings/UR-06/AGENTS.md
+++ b/crates/trios-ui/rings/UR-06/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md — UR-06
+
+## Agent: ALPHA
+- Add tool execution result display
+- Add tool parameter form (dynamic inputs from tool schema)
+- Add tool execution history
+
+## Agent: BETA
+- Test McpPanel with empty tool list
+- Test McpToolCard rendering with sample tools
+- Test connection status badge states
+
+## Rules
+- R1: Tool execution delegates to UR-07 via UR-00 atom
+- R2: Tool cards use Button and Badge from UR-02
+- R3: No direct WebSocket calls in this ring

--- a/crates/trios-ui/rings/UR-06/RING.md
+++ b/crates/trios-ui/rings/UR-06/RING.md
@@ -1,0 +1,23 @@
+# UR-06 — MCP Panel
+
+## Purpose
+MCP tools panel: lists available tools with status, shows connection status,
+and provides tool execution interface. Reads `McpAtom` from UR-00.
+
+## Public API
+- `McpPanel() -> Element` — full MCP tools panel with connection status and tool list
+- `McpToolCardProps` — props: `tool: McpTool`
+- `McpToolCard(props) -> Element` — single tool card with name, description, execute button
+
+## Dependencies
+- `trios-ui-ur00` — `use_mcp_atom()`, `McpTool`
+- `trios-ui-ur01` — `use_palette()`, `radius`, `spacing`, `typography`
+- `trios-ui-ur02` — `Badge`, `BadgeVariant`, `Button`, `ButtonVariant`
+
+## Ring Rules
+- R1: Only ring that renders MCP tools
+- R2: Tool execution goes through UR-07 WebSocket client (via UR-00 atom)
+- R3: Connection status badge shows connected/disconnected state
+
+## Compilation Status
+Blocked on UR-00/UR-01/UR-02 compilation.

--- a/crates/trios-ui/rings/UR-06/TASK.md
+++ b/crates/trios-ui/rings/UR-06/TASK.md
@@ -1,0 +1,11 @@
+# TASK.md — UR-06
+
+## Current
+- [x] McpPanel with connection status and tool list
+- [x] McpToolCard with name, description, execute button
+
+## Next
+- [ ] Add tool execution result display (JSON formatting)
+- [ ] Add dynamic parameter form from tool schema
+- [ ] Add tool execution history log
+- [ ] Add tool search/filter

--- a/docs/TRAINING_FLOW_V2.md
+++ b/docs/TRAINING_FLOW_V2.md
@@ -1,0 +1,54 @@
+# Training-Flow V2 — Gate-2 Push Plan
+
+> **Target:** BPB < 1.85 on 3 seeds (quorum 3/3) before deadline
+> **Champion baseline:** BPB = 2.2393 @ 27K steps, seed=43 (commit 2446855)
+> **Gap to close:** 0.39 BPB points
+
+## Phase P0 — Audit (Champion Reproduction)
+
+**Hypothesis:** Champion config reproduces BPB=2.2393 ± 0.01
+**Exit criterion:** 3/3 seeds within 0.01 of baseline
+**Status:** Done
+
+## Phase P1 — Optimizer Lab (Muon vs AdamW)
+
+**Hypothesis:** Muon optimizer achieves >0.05 BPB improvement over AdamW
+**Exit criterion:** Paired t-test p < 0.05, n >= 3 seeds
+**Status:** In progress
+
+Configs:
+- `config_muon105.toml` — Muon with lr=1e-3
+- AdamW baseline with same lr schedule
+
+## Phase P2 — μP Transfer (8M → 70M Scaling)
+
+**Hypothesis:** μP transfer scales loss monotonically from 8M to 70M params
+**Exit criterion:** 70M loss < 8M loss, delta > 0.1 BPB
+**Status:** Planned
+
+## Phase P3 — Schedule-Free + WSD
+
+**Hypothesis:** Schedule-Free or WSD scheduler beats cosine by >0.03 BPB
+**Exit criterion:** Best scheduler wins paired comparison
+**Status:** Planned
+
+## Phase P4 — Multi-Objective + EMA (JEPA + NCA)
+
+**Hypothesis:** Joint JEPA+NCA objective beats single-task CE
+**Exit criterion:** Multi-obj BPB < single-task BPB by >0.02
+**Status:** Planned
+
+## Phase P5 — Gate-2 Push (3 seeds < 1.85)
+
+**Hypothesis:** Best config from P1-P4 achieves BPB < 1.85 on seeds {42,43,44}
+**Exit criterion:** `victory::check_victory()` returns Ok(VictoryReport) for 3/3 seeds
+**Status:** Planned
+
+## Pre-Registered Decision Matrix
+
+| Phase | Config | Seed(s) | Steps | BPB | Verdict | PR |
+|-------|--------|---------|-------|-----|---------|-----|
+| P0 | champion | 43 | 27K | 2.2393 | Reproduced | — |
+| P1 | pending | pending | pending | pending | pending | pending |
+
+Only merged PRs fill this matrix. No retroactive entries.


### PR DESCRIPTION
## Summary

- Add `crates/trios-train-cpu/README.md` with architecture overview, migration M0-M7 status, and Training-Flow V2 table
- Add `docs/TRAINING_FLOW_V2.md` with P0-P5 phases, falsifiable hypotheses, exit criteria, and pre-registered decision matrix

Closes #327