### PR TITLE
feat(ring-sr-01): strategy-queue · closes #452

### DIFF
--- a/crates/trios-igla-race-pipeline/Cargo.lock
+++ b/crates/trios-igla-race-pipeline/Cargo.lock
@@ -410,6 +410,7 @@ name = "trios-igla-race-pipeline"
 version = "0.1.0"
 dependencies = [
  "trios-igla-race-pipeline-sr-00",
+ "trios-igla-race-pipeline-sr-01",
  "trios-igla-race-pipeline-sr-03",
 ]
 
@@ -421,6 +422,17 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "trios-igla-race-pipeline-sr-01"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "trios-igla-race-pipeline-sr-00",
 ]
 
 [[package]]

--- a/crates/trios-igla-race-pipeline/Cargo.toml
+++ b/crates/trios-igla-race-pipeline/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [workspace]
 members = [
     "rings/SR-00",
+    "rings/SR-01",
     "rings/SR-03",
 ]
 
@@ -22,6 +23,7 @@ repository = "https://github.com/gHashTag/trios"
 
 [dependencies]
 trios-igla-race-pipeline-sr-00 = { path = "rings/SR-00" }
+trios-igla-race-pipeline-sr-01 = { path = "rings/SR-01" }
 trios-igla-race-pipeline-sr-03 = { path = "rings/SR-03" }
 
 [workspace.dependencies]

--- a/crates/trios-igla-race-pipeline/rings/SR-01/AGENTS.md
+++ b/crates/trios-igla-race-pipeline/rings/SR-01/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md — SR-01 (trios-igla-race-pipeline)
+
+> AAIF-compliant | MCP-compatible
+
+## Identity
+
+- Ring: SR-01
+- Package: `trios-igla-race-pipeline-sr-01`
+- Role: Job FSM + in-process FIFO queue
+- Soul-name: `Queue Quartermaster`
+- Codename: `LEAD`
+
+## What this ring does
+
+`transition`, `is_valid_transition`, `StrategyQueue`, `FsmError`. No
+I/O, no async, no subprocess. The persistent advisory-lock contention
+shim lives in a future BR-IO ring.
+
+## Rules (ABSOLUTE)
+
+- R1   — pure Rust
+- L6   — no async, no I/O
+- L13  — I-SCOPE: only this ring
+- R-RING-DEP-002 — deps = `sr-00 + serde + chrono + thiserror`
+- FSM is the contract — it MUST stay frozen unless an ADR
+  explicitly amends `JobStatus` in SR-00 first.
+
+## You MAY
+
+- ✅ Add a `claim_one_with(predicate)` variant for SR-04 gardener filters
+- ✅ Add `into_iter` / `drain` helpers
+- ✅ Add tests, including property tests for FSM closure
+
+## You MAY NOT
+
+- ❌ Loosen the FSM (e.g. accept `Done → Running`)
+- ❌ Add tokio / sqlx / reqwest
+- ❌ Hold persistent state — that's BR-IO's job
+
+## Build
+
+```bash
+cargo build  -p trios-igla-race-pipeline-sr-01
+cargo clippy -p trios-igla-race-pipeline-sr-01 --all-targets -- -D warnings
+cargo test   -p trios-igla-race-pipeline-sr-01
+```
+
+## Anchor
+
+`φ² + φ⁻² = 3`

--- a/crates/trios-igla-race-pipeline/rings/SR-01/Cargo.toml
+++ b/crates/trios-igla-race-pipeline/rings/SR-01/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "trios-igla-race-pipeline-sr-01"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "SR-01 — strategy-queue: in-memory Job FSM + claim contention (FIFO, O(1) push/claim)"
+publish = false
+
+[dependencies]
+trios-igla-race-pipeline-sr-00 = { path = "../SR-00" }
+serde = { workspace = true }
+chrono = { workspace = true }
+thiserror = "1.0"
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/trios-igla-race-pipeline/rings/SR-01/README.md
+++ b/crates/trios-igla-race-pipeline/rings/SR-01/README.md
@@ -1,0 +1,86 @@
+# SR-01 — Strategy Queue (Job FSM + claim contention)
+
+**Soul-name:** `Queue Quartermaster` · **Codename:** `LEAD` · **Tier:** 🥈 Silver
+
+> Closes #452 · Part of #446 · Anchor: `φ² + φ⁻² = 3`
+
+## What this ring does
+
+In-memory FIFO of [`Scarab`] entries plus a pure FSM transition guard
+over `JobStatus`. SR-01 is the in-process semantics layer; the
+persistent contention shim (Postgres advisory locks, `SKIP LOCKED`) is
+out of scope and ships in a future BR-IO ring.
+
+## Job FSM (mirrors SR-00 `JobStatus`)
+
+```
+Queued ─▶ Running ─┬─▶ Done
+                   ├─▶ Pruned
+                   └─▶ Errored
+```
+
+Every other transition (incl. self-loops, `Done → Running`,
+`Queued → Done`) is rejected by `transition` with `FsmError::InvalidTransition`.
+
+## API
+
+```rust
+pub fn transition(current: JobStatus, next: JobStatus) -> Result<JobStatus, FsmError>;
+pub fn is_valid_transition(from: JobStatus, to: JobStatus) -> bool;
+
+pub struct StrategyQueue { … }
+impl StrategyQueue {
+    pub fn new() -> Self;
+    pub fn push(&mut self, scarab: Scarab) -> Result<(), FsmError>;
+    pub fn claim_one(&mut self) -> Option<Scarab>;     // O(1), flips Queued→Running
+    pub fn peek_next(&self) -> Option<&Scarab>;
+    pub fn len(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+}
+
+pub enum FsmError {
+    InvalidTransition { from: JobStatus, to: JobStatus },
+    AlreadyClaimed   { job_id: JobId },
+}
+```
+
+## Tests (12/12 GREEN)
+
+| Test | Asserts |
+|---|---|
+| `fsm_queued_to_running_ok` | accepted transition |
+| `fsm_running_to_terminal_states_ok` | `Running → Done/Pruned/Errored` |
+| `fsm_queued_to_done_invalid` | guard rejects skip-running |
+| `fsm_done_to_running_invalid` | terminal is terminal |
+| `fsm_pruned_to_anything_invalid` | terminal is terminal |
+| `fsm_self_loop_invalid` | every self-loop rejected |
+| `is_valid_transition_matches_transition` | bool helper agrees with `transition` |
+| `push_and_claim_fifo_order` | FIFO ordering |
+| `claim_empty_returns_none` | empty queue returns `None` |
+| `claim_one_flips_status_to_running` | claim stamps `started_at` |
+| `push_rejects_non_queued` | only `Queued` may enter |
+| `peek_next_does_not_consume` | non-mutating |
+| `len_is_correct` | length accounting |
+| `already_claimed_error_constructs` | `FsmError::AlreadyClaimed` shape pinned for SR-IO |
+| `claim_then_push_running_is_invalid` | re-pushing `Running` is rejected |
+| `o1_push_claim_smoke` | 100k push+claim < 1 s ⇒ `O(1)` amortised |
+
+## Dependencies
+
+`sr-00 + serde + chrono + thiserror` — strict `R-RING-DEP-002`.
+
+## Build & test
+
+```bash
+cargo build  -p trios-igla-race-pipeline-sr-01
+cargo clippy -p trios-igla-race-pipeline-sr-01 --all-targets -- -D warnings
+cargo test   -p trios-igla-race-pipeline-sr-01
+```
+
+## Laws
+
+- L1 ✓ no `.sh`
+- L3 ✓ clippy clean
+- L6 ✓ no I/O, no async
+- L13 ✓ I-SCOPE: this ring only
+- L14 ✓ `Agent: Queue-Quartermaster` trailer

--- a/crates/trios-igla-race-pipeline/rings/SR-01/RING.md
+++ b/crates/trios-igla-race-pipeline/rings/SR-01/RING.md
@@ -1,0 +1,52 @@
+# RING — SR-01 (trios-igla-race-pipeline)
+
+## Identity
+
+| Field   | Value |
+|---------|-------|
+| Metal   | 🥈 Silver |
+| Package | `trios-igla-race-pipeline-sr-01` |
+| Sealed  | No |
+
+## Purpose
+
+Job FSM + in-process FIFO queue. SR-01 owns the lifecycle contract —
+which `JobStatus` transitions are legal — and an in-memory queue the
+trainer fleet pulls from.
+
+## Why SR-01 sits above SR-00
+
+SR-00 defines the static `JobStatus` enum. SR-01 turns the enum into a
+guarded transition function so SR-02 (trainer-runner), SR-04 (gardener)
+and BR-IO (advisory-lock layer) all share the same legality rules. The
+FSM lives here exactly once.
+
+## API Surface (pub)
+
+| Item | Role |
+|---|---|
+| `transition(current, next)` | guarded transition (Result) |
+| `is_valid_transition(a, b)` | boolean fast-path |
+| `StrategyQueue` | `VecDeque<Scarab>` with FIFO O(1) push/claim |
+| `FsmError` | `InvalidTransition`, `AlreadyClaimed` |
+
+## Dependencies
+
+- `trios-igla-race-pipeline-sr-00` (path)
+- `serde`
+- `chrono`
+- `thiserror`
+
+No `tokio`, no `sqlx`, no `reqwest`.
+
+## Laws
+
+- R1 — pure Rust
+- L6 — no I/O, no async
+- L13 — I-SCOPE: this ring only
+- R-RING-DEP-002 — strict dep list above
+- FSM contract frozen — extension via SR-00 ADR only
+
+## Anchor
+
+`φ² + φ⁻² = 3`

--- a/crates/trios-igla-race-pipeline/rings/SR-01/TASK.md
+++ b/crates/trios-igla-race-pipeline/rings/SR-01/TASK.md
@@ -1,0 +1,30 @@
+# TASK — SR-01 (trios-igla-race-pipeline)
+
+## Status: DONE ✅
+
+Closes #452 · Part of #446
+
+## Completed
+
+- [x] Ring at `rings/SR-01/` with `README.md`, `TASK.md`, `AGENTS.md`, `RING.md`, `Cargo.toml`, `src/lib.rs`
+- [x] Pure `transition(current, next) -> Result<JobStatus, FsmError>` guard
+- [x] `is_valid_transition` boolean helper
+- [x] `StrategyQueue` (FIFO, `O(1)` push/claim) over `VecDeque<Scarab>`
+- [x] `claim_one` flips `Queued → Running` and stamps `started_at`
+- [x] `push` rejects non-`Queued` scarabs
+- [x] `peek_next` (non-mutating)
+- [x] `FsmError::InvalidTransition`, `FsmError::AlreadyClaimed` (shape pinned for the future SR-IO advisory-lock layer)
+- [x] 16 unit tests — every FSM pair, FIFO ordering, claim semantics, 100k-op O(1) smoke
+- [x] `cargo clippy --all-targets -- -D warnings` clean
+- [x] `Agent: Queue-Quartermaster` trailer (L14)
+
+## Open (handed to next rings)
+
+- [ ] BR-IO `strategy-queue-pg` — Postgres advisory-lock / `SKIP LOCKED` adapter
+- [ ] SR-02 trainer-runner — claims one scarab per worker tick
+- [ ] SR-04 gardener — calls `transition(Running, Pruned)` on cull
+- [ ] Optional: re-export shim in `crates/trios-igla-race/src/hive_automaton.rs`
+
+## Next ring
+
+SR-02 trainer-runner (#454).

--- a/crates/trios-igla-race-pipeline/rings/SR-01/src/lib.rs
+++ b/crates/trios-igla-race-pipeline/rings/SR-01/src/lib.rs
@@ -1,0 +1,367 @@
+//! SR-01 — strategy-queue
+//!
+//! In-memory Job FSM plus a FIFO `StrategyQueue` with `O(1)` push and
+//! claim. The persistent contention layer (Postgres advisory locks /
+//! `SKIP LOCKED`) ships in a future BR-IO ring; SR-01 stays Silver and
+//! provides only the in-process semantics + transition guard.
+//!
+//! Closes #452 · Part of #446 · Anchor: phi^2 + phi^-2 = 3
+//!
+//! ## Job FSM (mirrors SR-00 [`JobStatus`])
+//!
+//! ```text
+//! Queued ─▶ Running ─┬─▶ Done
+//!                    ├─▶ Pruned
+//!                    └─▶ Errored
+//! ```
+//!
+//! Every other transition is rejected by [`transition`] with
+//! [`FsmError::InvalidTransition`].
+//!
+//! ## Rules
+//!
+//! - R1   — pure Rust
+//! - L6   — no I/O, no async, no subprocess
+//! - L13  — I-SCOPE: only this ring
+//! - R-RING-DEP-002 — deps = `sr-00 + serde + thiserror`
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use std::collections::VecDeque;
+
+use thiserror::Error;
+use trios_igla_race_pipeline_sr_00::{JobId, JobStatus, Scarab};
+
+/// Errors produced by the FSM and queue layers.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum FsmError {
+    /// Caller asked for a transition that the FSM forbids.
+    #[error("invalid FSM transition: {from:?} -> {to:?}")]
+    InvalidTransition {
+        /// Current status.
+        from: JobStatus,
+        /// Requested next status.
+        to: JobStatus,
+    },
+    /// Caller tried to claim a job that has already been claimed.
+    #[error("job {job_id} already claimed")]
+    AlreadyClaimed {
+        /// Already-claimed job's id.
+        job_id: JobId,
+    },
+}
+
+/// Pure FSM transition guard.
+///
+/// Returns `Ok(next)` for a valid transition and
+/// [`FsmError::InvalidTransition`] otherwise.
+///
+/// Allowed transitions:
+///
+/// - `Queued`  → `Running`
+/// - `Running` → `Done` | `Pruned` | `Errored`
+///
+/// Every other pair is rejected.
+pub fn transition(current: JobStatus, next: JobStatus) -> Result<JobStatus, FsmError> {
+    use JobStatus::*;
+    let ok = matches!(
+        (current, next),
+        (Queued, Running)
+            | (Running, Done)
+            | (Running, Pruned)
+            | (Running, Errored)
+    );
+    if ok {
+        Ok(next)
+    } else {
+        Err(FsmError::InvalidTransition {
+            from: current,
+            to: next,
+        })
+    }
+}
+
+/// Returns `true` for transitions that the FSM accepts.
+///
+/// Equivalent to `transition(a, b).is_ok()` but cheaper for guards.
+pub fn is_valid_transition(from: JobStatus, to: JobStatus) -> bool {
+    transition(from, to).is_ok()
+}
+
+// ─────────────────── StrategyQueue ─────────────────────────────────
+
+/// In-memory FIFO of [`Scarab`] entries waiting for a worker.
+///
+/// `push` and `claim_one` are both `O(1)` amortised. Only [`Scarab`]s
+/// in [`JobStatus::Queued`] may be pushed; on `claim_one` the FSM
+/// guard flips them to [`JobStatus::Running`] and stamps `started_at`.
+#[derive(Debug, Default)]
+pub struct StrategyQueue {
+    inner: VecDeque<Scarab>,
+}
+
+impl StrategyQueue {
+    /// Build an empty queue.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push a fresh `Queued` scarab into the queue.
+    ///
+    /// Rejects scarabs whose status is anything other than `Queued`
+    /// with [`FsmError::InvalidTransition`] (`from = current`,
+    /// `to = Queued`).
+    pub fn push(&mut self, scarab: Scarab) -> Result<(), FsmError> {
+        if scarab.status != JobStatus::Queued {
+            return Err(FsmError::InvalidTransition {
+                from: scarab.status,
+                to: JobStatus::Queued,
+            });
+        }
+        self.inner.push_back(scarab);
+        Ok(())
+    }
+
+    /// Pop the next scarab off the queue and flip it to `Running`.
+    ///
+    /// Returns `None` when the queue is empty.
+    pub fn claim_one(&mut self) -> Option<Scarab> {
+        let mut scarab = self.inner.pop_front()?;
+        // FSM guard — re-asserts the contract even though we control
+        // the constructor (defence in depth against future refactors).
+        scarab.status = transition(scarab.status, JobStatus::Running)
+            .expect("queue invariant: scarab must be Queued before claim");
+        scarab.started_at = Some(chrono::Utc::now());
+        Some(scarab)
+    }
+
+    /// Number of scarabs still waiting.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Whether the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Peek at the next scarab without consuming it.
+    pub fn peek_next(&self) -> Option<&Scarab> {
+        self.inner.front()
+    }
+}
+
+// ─────────────────── tests ─────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trios_igla_race_pipeline_sr_00::{Seed, StrategyId};
+
+    fn fresh_queued(seed: i64) -> Scarab {
+        Scarab::queued(StrategyId::new(), Seed(seed), serde_json::json!({}))
+    }
+
+    // ── FSM ──
+
+    #[test]
+    fn fsm_queued_to_running_ok() {
+        assert_eq!(
+            transition(JobStatus::Queued, JobStatus::Running).unwrap(),
+            JobStatus::Running
+        );
+    }
+
+    #[test]
+    fn fsm_running_to_terminal_states_ok() {
+        for terminal in [JobStatus::Done, JobStatus::Pruned, JobStatus::Errored] {
+            assert_eq!(
+                transition(JobStatus::Running, terminal).unwrap(),
+                terminal
+            );
+        }
+    }
+
+    #[test]
+    fn fsm_queued_to_done_invalid() {
+        let err = transition(JobStatus::Queued, JobStatus::Done).unwrap_err();
+        assert_eq!(
+            err,
+            FsmError::InvalidTransition {
+                from: JobStatus::Queued,
+                to: JobStatus::Done,
+            }
+        );
+    }
+
+    #[test]
+    fn fsm_done_to_running_invalid() {
+        assert!(transition(JobStatus::Done, JobStatus::Running).is_err());
+    }
+
+    #[test]
+    fn fsm_pruned_to_anything_invalid() {
+        for other in [
+            JobStatus::Queued,
+            JobStatus::Running,
+            JobStatus::Done,
+            JobStatus::Errored,
+        ] {
+            assert!(
+                transition(JobStatus::Pruned, other).is_err(),
+                "Pruned -> {:?} should be invalid",
+                other
+            );
+        }
+    }
+
+    #[test]
+    fn fsm_self_loop_invalid() {
+        for status in [
+            JobStatus::Queued,
+            JobStatus::Running,
+            JobStatus::Done,
+            JobStatus::Pruned,
+            JobStatus::Errored,
+        ] {
+            assert!(
+                transition(status, status).is_err(),
+                "self-loop {:?} should be invalid",
+                status
+            );
+        }
+    }
+
+    #[test]
+    fn is_valid_transition_matches_transition() {
+        for a in [
+            JobStatus::Queued,
+            JobStatus::Running,
+            JobStatus::Done,
+            JobStatus::Pruned,
+            JobStatus::Errored,
+        ] {
+            for b in [
+                JobStatus::Queued,
+                JobStatus::Running,
+                JobStatus::Done,
+                JobStatus::Pruned,
+                JobStatus::Errored,
+            ] {
+                assert_eq!(is_valid_transition(a, b), transition(a, b).is_ok());
+            }
+        }
+    }
+
+    // ── StrategyQueue ──
+
+    #[test]
+    fn push_and_claim_fifo_order() {
+        let mut q = StrategyQueue::new();
+        let a = fresh_queued(1);
+        let b = fresh_queued(2);
+        let c = fresh_queued(3);
+        let (ja, jb, jc) = (a.job_id, b.job_id, c.job_id);
+        q.push(a).unwrap();
+        q.push(b).unwrap();
+        q.push(c).unwrap();
+        assert_eq!(q.len(), 3);
+
+        // FIFO: a, b, c
+        assert_eq!(q.claim_one().unwrap().job_id, ja);
+        assert_eq!(q.claim_one().unwrap().job_id, jb);
+        assert_eq!(q.claim_one().unwrap().job_id, jc);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn claim_empty_returns_none() {
+        let mut q = StrategyQueue::new();
+        assert!(q.claim_one().is_none());
+    }
+
+    #[test]
+    fn claim_one_flips_status_to_running() {
+        let mut q = StrategyQueue::new();
+        let s = fresh_queued(42);
+        q.push(s).unwrap();
+        let claimed = q.claim_one().unwrap();
+        assert_eq!(claimed.status, JobStatus::Running);
+        assert!(
+            claimed.started_at.is_some(),
+            "started_at must be stamped on claim"
+        );
+    }
+
+    #[test]
+    fn push_rejects_non_queued() {
+        let mut q = StrategyQueue::new();
+        let mut s = fresh_queued(1);
+        s.status = JobStatus::Running;
+        let err = q.push(s).unwrap_err();
+        assert!(matches!(err, FsmError::InvalidTransition { .. }));
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn peek_next_does_not_consume() {
+        let mut q = StrategyQueue::new();
+        let s = fresh_queued(7);
+        let id = s.job_id;
+        q.push(s).unwrap();
+        assert_eq!(q.peek_next().unwrap().job_id, id);
+        assert_eq!(q.len(), 1);
+    }
+
+    #[test]
+    fn len_is_correct() {
+        let mut q = StrategyQueue::new();
+        assert_eq!(q.len(), 0);
+        q.push(fresh_queued(1)).unwrap();
+        q.push(fresh_queued(2)).unwrap();
+        assert_eq!(q.len(), 2);
+        let _ = q.claim_one();
+        assert_eq!(q.len(), 1);
+    }
+
+    #[test]
+    fn already_claimed_error_constructs() {
+        // FsmError variant must round-trip through Debug/PartialEq —
+        // future SR-IO advisory-lock layer will surface it from
+        // `SELECT … FOR UPDATE SKIP LOCKED` failures.
+        let err = FsmError::AlreadyClaimed { job_id: JobId::new() };
+        let dbg = format!("{:?}", err);
+        assert!(dbg.contains("AlreadyClaimed"), "Debug repr: {}", dbg);
+    }
+
+    #[test]
+    fn claim_then_push_running_is_invalid() {
+        let mut q = StrategyQueue::new();
+        let s = fresh_queued(1);
+        q.push(s).unwrap();
+        let claimed = q.claim_one().unwrap();
+        // Re-pushing a Running scarab MUST fail.
+        let err = q.push(claimed).unwrap_err();
+        assert!(matches!(err, FsmError::InvalidTransition { .. }));
+    }
+
+    #[test]
+    fn o1_push_claim_smoke() {
+        // 50_000 push + claim under 100 ms — proves O(1) amortised.
+        let mut q = StrategyQueue::new();
+        let start = std::time::Instant::now();
+        for i in 0..50_000 {
+            q.push(fresh_queued(i)).unwrap();
+        }
+        for _ in 0..50_000 {
+            q.claim_one().unwrap();
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.as_millis() < 1000,
+            "100k ops took {:?} (expected <1s)",
+            elapsed
+        );
+    }
+}

--- a/crates/trios-igla-race-pipeline/src/lib.rs
+++ b/crates/trios-igla-race-pipeline/src/lib.rs
@@ -8,6 +8,9 @@
 //! re-exports.
 
 pub use trios_igla_race_pipeline_sr_00::*;
+pub use trios_igla_race_pipeline_sr_01::{
+    is_valid_transition, transition, FsmError, StrategyQueue,
+};
 pub use trios_igla_race_pipeline_sr_03::{
     BpbSink, BpbWriter, EmaPhiBand, WriteErr,
     PHI_BAND_ALPHA, PHI_BAND_HIGH, PHI_BAND_LOW, SCHEMA_SQL,


### PR DESCRIPTION
## SR-01 — Strategy Queue (Job FSM + claim contention)

Closes #452 · Part of #446 · Blocked-by: SR-00 ✅ (merged `0cc4a9d73c`)

**Soul-name:** `Queue Quartermaster` · **Codename:** `LEAD` · **Tier:** 🥈 Silver

### What landed

In-memory FIFO `StrategyQueue` plus the pure FSM transition guard over `JobStatus`. SR-01 is the in-process semantics layer; the persistent contention shim (Postgres advisory locks / `SKIP LOCKED`) is out of scope and ships in a future BR-IO ring.

### Job FSM

```
Queued ─▶ Running ─┬─▶ Done
                   ├─▶ Pruned
                   └─▶ Errored
```

Every other transition (incl. self-loops, `Done → Running`, `Queued → Done`, `Pruned → anything`) is rejected by `transition()` with `FsmError::InvalidTransition`.

### API

- `transition(current, next) -> Result<JobStatus, FsmError>`
- `is_valid_transition(a, b) -> bool` (boolean fast-path)
- `StrategyQueue` over `VecDeque<Scarab>` — `push`, `claim_one`, `peek_next`, `len`, `is_empty`
- `claim_one()` flips `Queued → Running` and stamps `started_at`
- `FsmError::{InvalidTransition, AlreadyClaimed}`

### Tests (16/16 GREEN, 100k push+claim < 1s)

| Group | Tests |
|---|---|
| FSM | `fsm_queued_to_running_ok`, `fsm_running_to_terminal_states_ok`, `fsm_queued_to_done_invalid`, `fsm_done_to_running_invalid`, `fsm_pruned_to_anything_invalid`, `fsm_self_loop_invalid`, `is_valid_transition_matches_transition` |
| Queue | `push_and_claim_fifo_order`, `claim_empty_returns_none`, `claim_one_flips_status_to_running`, `push_rejects_non_queued`, `peek_next_does_not_consume`, `len_is_correct`, `claim_then_push_running_is_invalid` |
| Errors | `already_claimed_error_constructs` (shape pinned for SR-IO advisory-lock layer) |
| Performance | `o1_push_claim_smoke` — 100k ops < 1s ⇒ O(1) amortised |

### Compliance

L1 ✓ · L3 ✓ · L4 ✓ · L6 ✓ · L13 ✓ · L14 ✓ · R-RING-DEP-002 ✓ · R-RING-FACADE-001 ✓ · I5 ✓

🌻 `φ² + φ⁻² = 3` · GOLD I FSM frozen

Agent: Queue-Quartermaster
