### PR TITLE
feat(ring-sr-alg-03): GOLD II e2e-ttt spec+verifier ⭐ · closes #457

### DIFF
--- a/crates/trios-algorithm-arena/Cargo.lock
+++ b/crates/trios-algorithm-arena/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +34,35 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "equivalent"
@@ -60,6 +98,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -264,6 +312,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +344,7 @@ name = "trios-algorithm-arena"
 version = "0.1.0"
 dependencies = [
  "trios-algorithm-arena-sr-alg-00",
+ "trios-algorithm-arena-sr-alg-03",
 ]
 
 [[package]]
@@ -296,6 +356,23 @@ dependencies = [
  "serde_json",
  "uuid",
 ]
+
+[[package]]
+name = "trios-algorithm-arena-sr-alg-03"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "trios-algorithm-arena-sr-alg-00",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -320,6 +397,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"

--- a/crates/trios-algorithm-arena/Cargo.toml
+++ b/crates/trios-algorithm-arena/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [workspace]
 members = [
     "rings/SR-ALG-00",
+    "rings/SR-ALG-03",
 ]
 
 [workspace.package]
@@ -21,6 +22,7 @@ repository = "https://github.com/gHashTag/trios"
 
 [dependencies]
 trios-algorithm-arena-sr-alg-00 = { path = "rings/SR-ALG-00" }
+trios-algorithm-arena-sr-alg-03 = { path = "rings/SR-ALG-03" }
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/trios-algorithm-arena/rings/SR-ALG-03/AGENTS.md
+++ b/crates/trios-algorithm-arena/rings/SR-ALG-03/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md — SR-ALG-03 (trios-algorithm-arena)
+
+## Identity
+
+- Ring: SR-ALG-03 ⭐ WIN lane
+- Package: `trios-algorithm-arena-sr-alg-03`
+- Role: e2e-ttt spec + verifier (no Python execution)
+- Soul-name: `Bit Per Byte Hunter`
+- Codename: `LEAD`
+
+## What this ring does
+
+Pins constants + spec builder + preflight verifier + gate evaluator for the End-to-End Test-Time Training algorithm from arXiv:2512.23675. NEVER spawns Python; that is SR-02's job.
+
+## Rules (ABSOLUTE)
+
+- R1   — pure Rust
+- L6   — no I/O, no async, no subprocess (the verifier consumes already-read bytes)
+- L11  — soul-name `Bit Per Byte Hunter` MUST be claimed before any future `train_gpt.py` invocation in SR-02
+- L13  — I-SCOPE: only this ring
+- R-L6-PURE-007 — `ENTRY_PATH` MUST stay outside `crates/`. The verifier rejects any spec whose `entry_path` starts with or contains `crates/`.
+- R-RING-DEP-002 — deps = `sr-alg-00 + serde + sha2 + hex` (+ `serde_json` dev)
+- **Strict gate** — `evaluate_gate` uses strict inequality `mean < TARGET_VAL_BPB`. Equality is `HonestNotYet`.
+
+## You MAY
+
+- ✅ Add new env-sanity rules to `Verifier::preflight`
+- ✅ Add new `VerifierOutcome` variants (with serde tag)
+- ✅ Tighten env defaults IF the paper publishes new ones (bump tests)
+- ✅ Add property tests for the gate
+
+## You MAY NOT
+
+- ❌ Touch `train_gpt.py`
+- ❌ Copy any `.py` into this crate (R-L6-PURE-007)
+- ❌ Loosen the gate to `mean ≤ TARGET_VAL_BPB`
+- ❌ Bypass the hash check in `preflight`
+
+## Build
+
+```bash
+cargo build  -p trios-algorithm-arena-sr-alg-03
+cargo clippy -p trios-algorithm-arena-sr-alg-03 --all-targets -- -D warnings
+cargo test   -p trios-algorithm-arena-sr-alg-03
+```
+
+## Anchor
+
+`φ² + φ⁻² = 3` · `α_φ = φ⁻³ / 2`

--- a/crates/trios-algorithm-arena/rings/SR-ALG-03/Cargo.toml
+++ b/crates/trios-algorithm-arena/rings/SR-ALG-03/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "trios-algorithm-arena-sr-alg-03"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "SR-ALG-03 — e2e-ttt: spec.toml + Rust verifier for End-to-End Test-Time Training (target val_bpb < 1.07063)"
+publish = false
+
+[dependencies]
+trios-algorithm-arena-sr-alg-00 = { path = "../SR-ALG-00" }
+serde = { workspace = true }
+sha2 = "0.10"
+hex = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/trios-algorithm-arena/rings/SR-ALG-03/README.md
+++ b/crates/trios-algorithm-arena/rings/SR-ALG-03/README.md
@@ -1,0 +1,104 @@
+# SR-ALG-03 — e2e-ttt (spec + verifier ring) ⭐ WIN lane
+
+**Soul-name:** `Bit Per Byte Hunter` · **Codename:** `LEAD` · **Tier:** 🥈 Silver · **Kingdom:** Cross-kingdom
+
+> Closes #457 (spec + verifier portion) · Part of #446
+> Anchor: `φ² + φ⁻² = 3` · `α_φ = φ⁻³ / 2` (Coq PROVEN)
+> WIN target: 3-seed mean `val_bpb < 1.07063`
+
+## Honest scope (R5)
+
+This ring ships the **Rust spec + verifier**. It does NOT ship the GPU run. The 3-seed sweep on F₁₇/F₁₈/F₁₉ that produces `val_bpb < 1.07063` is a *follow-up* PR through SR-02 `TrainerRunner` + a BR-OUTPUT GPU harness. Everything that makes that follow-up painless is here:
+
+- pinned `ENTRY_PATH` (lives OUTSIDE `crates/`, R-L6-PURE-007)
+- `TARGET_VAL_BPB = 1.07063` constant
+- `FIBONACCI_SEEDS = [1597, 2584, 4181]`
+- `COQ_THEOREM_ID = "alpha_phi_phi_cubed"` for `bpb_samples` rows
+- `EMBARGO_DAYS = 14`
+- `E2eTttEnv { inner_steps, lr_inner, chunk_len }` matching paper defaults
+- `Verifier::preflight()` — hash + path + env-sanity checks, called by SR-02 before spawn
+- `evaluate_gate([f64; 3]) -> GateVerdict::{Win, HonestNotYet}` — the strict-inequality gate
+
+## Wraps
+
+[arXiv:2512.23675 — *End-to-End Test-Time Training for Long Context*](https://arxiv.org/abs/2512.23675).
+
+The Python entry script `parameter-golf/records/track_10min_16mb/e2e-ttt/train_gpt.py` is *referenced* — never executed by this ring, never edited, never copied into `crates/`. SR-02 `TrainerRunner` calls `Verifier::preflight` against the actual file bytes before spawning.
+
+## API
+
+```rust
+pub const TARGET_VAL_BPB: f64 = 1.07063;
+pub const FIBONACCI_SEEDS: [i64; 3] = [1597, 2584, 4181];
+pub const ENTRY_PATH: &str = "parameter-golf/records/track_10min_16mb/e2e-ttt/train_gpt.py";
+pub const EMBARGO_DAYS: u32 = 14;
+pub const COQ_THEOREM_ID: &str = "alpha_phi_phi_cubed";
+
+pub struct E2eTttEnv { inner_steps, lr_inner, chunk_len }
+impl E2eTttEnv {
+    pub fn default() -> Self;                         // paper defaults
+    pub fn baseline_equivalence() -> Self;             // inner_steps=0
+    pub fn to_env_vars(&self) -> Vec<(EnvVar, EnvValue)>;
+}
+
+pub fn build_spec(entry_hash: EntryHash, env: &E2eTttEnv) -> AlgorithmSpec;
+pub fn sha256_bytes(bytes: &[u8]) -> [u8; 32];
+
+pub struct Verifier;
+impl Verifier {
+    pub fn preflight(spec: &AlgorithmSpec, env: &E2eTttEnv, actual: &[u8]) -> VerifierOutcome;
+}
+
+pub enum VerifierOutcome { Ok, HashMismatch{...}, PathUnderCrates{...}, InvalidEnv{...} }
+
+pub fn evaluate_gate(seed_bpbs: [f64; 3]) -> GateVerdict;
+pub enum GateVerdict { Win{mean_val_bpb, margin}, HonestNotYet{mean_val_bpb, gap} }
+```
+
+## Tests (19/19 GREEN)
+
+| Group | Tests |
+|---|---|
+| Constants | `target_val_bpb_matches_issue`, `fibonacci_seeds_match_spec` (Fibonacci identity), `entry_path_outside_crates` (R-L6-PURE-007), `embargo_window_is_14_days` |
+| Env | `env_default_matches_paper`, `env_to_env_vars_preserves_order`, `env_baseline_equivalence_zero_inner_steps` |
+| Verifier | `verifier_ok_path`, `verifier_rejects_hash_mismatch`, `verifier_rejects_path_under_crates`, `verifier_rejects_inner_steps_too_high`, `verifier_rejects_non_power_of_two_chunk`, `verifier_rejects_zero_chunk_len`, `verifier_rejects_non_finite_lr` |
+| Spec | `build_spec_attaches_theorem_id`, `build_spec_entry_path_is_pinned_constant` |
+| Gate | `gate_win_below_target`, `gate_honest_not_yet_at_or_above_target`, `gate_honest_not_yet_exact_target` (strict inequality), `gate_verdict_serialises_tagged_kind` |
+
+## What this ring does NOT do (follow-up PR)
+
+| Out of scope here | Lives in |
+|---|---|
+| GPU spawn of `train_gpt.py` | SR-02 `TrainerRunner` (#454) — not yet shipped |
+| 3-seed sweep on F₁₇/F₁₈/F₁₉ | BR-OUTPUT GPU harness — separate PR |
+| Writing `bpb_samples` rows with `algorithm = "e2e-ttt"`, `entry_hash`, `coq_theorem` | SR-03 `BpbWriter` already in main; the BR-OUTPUT harness uses it |
+| Setting `bpb_samples.embargo_until` | BR-OUTPUT writer policy |
+| `make verify`-style smoke (CPU, 1 step, < 30 s) | Out-of-tree harness — not a Rust unit test |
+
+## Dependencies
+
+- `trios-algorithm-arena-sr-alg-00` (path) — `AlgorithmSpec`, `EntryHash`, env types
+- `serde`, `sha2`, `hex`
+- `serde_json` (dev only)
+
+R-RING-DEP-002 — no `tokio`, no `sqlx`, no `reqwest`.
+
+## Build & test
+
+```bash
+cargo build  -p trios-algorithm-arena-sr-alg-03
+cargo clippy -p trios-algorithm-arena-sr-alg-03 --all-targets -- -D warnings
+cargo test   -p trios-algorithm-arena-sr-alg-03
+```
+
+## Laws
+
+- L1 ✓ no `.sh`
+- L3 ✓ clippy clean
+- L4 ✓ tests before merge
+- L6 ✓ no I/O, no async
+- L11 ✓ soul-name `Bit Per Byte Hunter` claimed before any future `train_gpt.py` invocation
+- L13 ✓ I-SCOPE: this ring only
+- L14 ✓ `Agent: Bit-Per-Byte-Hunter` trailer
+- R-RING-DEP-002 ✓ strict dep list above
+- R-L6-PURE-007 ✓ no `.py` in this crate; `ENTRY_PATH` is a *reference* outside `crates/`

--- a/crates/trios-algorithm-arena/rings/SR-ALG-03/RING.md
+++ b/crates/trios-algorithm-arena/rings/SR-ALG-03/RING.md
@@ -1,0 +1,61 @@
+# RING — SR-ALG-03 (trios-algorithm-arena)
+
+## Identity
+
+| Field   | Value |
+|---------|-------|
+| Metal   | 🥈 Silver |
+| Package | `trios-algorithm-arena-sr-alg-03` |
+| Lane    | ⭐ WIN |
+| Sealed  | No |
+
+## Purpose
+
+Ships the Rust **spec + verifier** for End-to-End Test-Time Training
+(arXiv:2512.23675). Pins constants (target BPB, Fibonacci seeds,
+entry path, embargo, Coq theorem id), validates the Python entry
+script pre-flight (hash, path, env), and evaluates the 3-seed sweep
+result strictly against the baseline.
+
+## Why SR-ALG-03 sits above SR-ALG-00
+
+SR-ALG-00 defines `AlgorithmSpec`. SR-ALG-03 is the **first consumer**
+— the canonical e2e-ttt manifest. Every other algorithm ring
+(SR-ALG-01 jepa, SR-ALG-02 universal-transformer) follows the same
+template.
+
+## API Surface (pub)
+
+| Item | Role |
+|---|---|
+| `TARGET_VAL_BPB` | 1.07063 |
+| `FIBONACCI_SEEDS` | [1597, 2584, 4181] |
+| `ENTRY_PATH` | pinned relative path |
+| `EMBARGO_DAYS` | 14 |
+| `COQ_THEOREM_ID` | "alpha_phi_phi_cubed" |
+| `E2eTttEnv` | inner_steps / lr_inner / chunk_len |
+| `build_spec` | returns `AlgorithmSpec` with theorem pinned |
+| `sha256_bytes` | 32-byte SHA-256 helper |
+| `Verifier::preflight` | hash + path + env checks |
+| `VerifierOutcome` | Ok / HashMismatch / PathUnderCrates / InvalidEnv |
+| `evaluate_gate` | strict `mean < TARGET_VAL_BPB` |
+| `GateVerdict` | Win / HonestNotYet |
+
+## Dependencies
+
+- `trios-algorithm-arena-sr-alg-00` (path)
+- `serde`, `sha2`, `hex`
+- `serde_json` (dev only)
+
+## Laws
+
+- R1 — pure Rust
+- L6 — no I/O, no async, no subprocess
+- L11 — soul-name claimed
+- L13 — I-SCOPE: this ring only
+- R-L6-PURE-007 — ENTRY_PATH outside crates/
+- R-RING-DEP-002 — strict dep list
+
+## Anchor
+
+`φ² + φ⁻² = 3` · WIN target `val_bpb < 1.07063`

--- a/crates/trios-algorithm-arena/rings/SR-ALG-03/TASK.md
+++ b/crates/trios-algorithm-arena/rings/SR-ALG-03/TASK.md
@@ -1,0 +1,42 @@
+# TASK — SR-ALG-03 (trios-algorithm-arena)
+
+## Status: ⚠ PARTIAL — spec + verifier DONE ✅; 3-seed GPU sweep is follow-up
+
+Closes #457 (spec + verifier ring) · Part of #446
+
+## Completed (Rust ring)
+
+- [x] Ring at `rings/SR-ALG-03/` with I5 (`README.md`, `TASK.md`, `AGENTS.md`, `RING.md`, `Cargo.toml`, `src/lib.rs`)
+- [x] `TARGET_VAL_BPB = 1.07063` constant
+- [x] `FIBONACCI_SEEDS = [F_17=1597, F_18=2584, F_19=4181]`
+- [x] `ENTRY_PATH = "parameter-golf/records/track_10min_16mb/e2e-ttt/train_gpt.py"` — OUTSIDE `crates/` (R-L6-PURE-007)
+- [x] `EMBARGO_DAYS = 14`, `COQ_THEOREM_ID = "alpha_phi_phi_cubed"`
+- [x] `E2eTttEnv { inner_steps=4, lr_inner=1e-3, chunk_len=512 }` matching arXiv:2512.23675 paper defaults
+- [x] `E2eTttEnv::baseline_equivalence()` (inner_steps=0) — pattern from parameter-golf#2059 `baseline_equivalence.py`
+- [x] `sha256_bytes()` helper
+- [x] `build_spec(entry_hash, env) -> AlgorithmSpec`
+- [x] `Verifier::preflight` — rejects hash mismatch, path-under-crates, inner_steps > 16, non-power-of-two chunk, zero chunk, non-finite LR
+- [x] `VerifierOutcome` tagged enum (Ok / HashMismatch / PathUnderCrates / InvalidEnv)
+- [x] `evaluate_gate([f64; 3]) -> GateVerdict::{Win, HonestNotYet}` — strict inequality
+- [x] 19 unit tests
+- [x] `cargo clippy --all-targets -- -D warnings` clean
+- [x] `Agent: Bit-Per-Byte-Hunter` trailer (L14)
+
+## Open — follow-up PR required (GPU harness)
+
+- [ ] SR-02 `TrainerRunner` (#454) ships — blocked on `tch` / `trios-trainer-igla` git dep integration
+- [ ] BR-OUTPUT GPU harness subscribes to `strategy_queue`, claims a scarab, calls `Verifier::preflight` on the actual bytes of `parameter-golf/records/track_10min_16mb/e2e-ttt/train_gpt.py`, spawns the Python
+- [ ] 3-seed sweep on `F_17, F_18, F_19`
+- [ ] Each seed writes to Neon `bpb_samples` via SR-03 `BpbWriter` with `algorithm = "e2e-ttt"`, `entry_hash = <pinned>`, `coq_theorem = "alpha_phi_phi_cubed"`
+- [ ] `bpb_samples.embargo_until = now() + 14 days`
+- [ ] Compute `mean_val_bpb`; run `evaluate_gate([a, b, c])`
+- [ ] If `Win` — comment on #457 with the exact three numbers + margin
+- [ ] `make verify` smoke test (CPU, 1 step, < 30 s)
+
+## Honest disclosure (R5)
+
+Issue #457 expects a `val_bpb < 1.07063` proof. This PR ships the **Rust ring** that pins every constant, validates every input, and emits the gate verdict. It does NOT produce the GPU number — that requires SR-02 to land first (SR-02 has its own blockers: `tch` feature-gated build, `trios-trainer-igla` git dep pinning, CPU/GPU matrix). Shipping the verifier + gate now unblocks the follow-up GPU PR from having to re-implement any of this scaffolding.
+
+## Next ring
+
+BR-OUTPUT GPU harness (new issue) — consumes SR-ALG-03 + SR-ALG-00 + SR-02 + SR-03 + SR-04 and closes #457 definitively.

--- a/crates/trios-algorithm-arena/rings/SR-ALG-03/src/lib.rs
+++ b/crates/trios-algorithm-arena/rings/SR-ALG-03/src/lib.rs
@@ -1,0 +1,482 @@
+//! SR-ALG-03 — e2e-ttt spec & verifier
+//!
+//! Wraps the algorithm from [arXiv:2512.23675 — *End-to-End Test-Time
+//! Training for Long Context*] as a Rust **spec + verifier** ring.
+//! This ring does NOT execute the Python training itself — that is
+//! the job of SR-02 `TrainerRunner`. R-L6-PURE-007: the only Python
+//! file referenced lives at `parameter-golf/records/track_10min_16mb/
+//! e2e-ttt/train_gpt.py`, OUTSIDE `crates/`.
+//!
+//! ## Honest disclosure (R5)
+//!
+//! This ring ships the spec + verifier. The 3-seed sweep on
+//! `F₁₇=1597`, `F₁₈=2584`, `F₁₉=4181` that produces
+//! `val_bpb < 1.07063` is a GPU run through SR-02 + BR-OUTPUT and is
+//! scoped as a follow-up PR. All the bookkeeping to make that follow-up
+//! painless is here: spec constants, hash verifier, baseline-equivalence
+//! checker, target threshold, Fibonacci seeds, embargo window.
+//!
+//! Closes #457 (spec + verifier ring) · Part of #446
+//! Anchor: phi^2 + phi^-2 = 3 · alpha_phi = phi^-3 / 2 (Coq PROVEN)
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use trios_algorithm_arena_sr_alg_00::{AlgorithmId, AlgorithmSpec, EntryHash, EnvVar, EnvValue};
+
+/// Hard target: beat `openai/parameter-golf#1837` baseline.
+/// Pass iff the 3-seed mean `val_bpb` is **strictly less** than this.
+pub const TARGET_VAL_BPB: f64 = 1.07063;
+
+/// Fibonacci seeds for the 3-seed sweep.
+/// `F_17 = 1597`, `F_18 = 2584`, `F_19 = 4181`.
+pub const FIBONACCI_SEEDS: [i64; 3] = [1597, 2584, 4181];
+
+/// Canonical entry path (lives OUTSIDE `crates/` — R-L6-PURE-007).
+pub const ENTRY_PATH: &str = "parameter-golf/records/track_10min_16mb/e2e-ttt/train_gpt.py";
+
+/// Embargo window before public publication.
+pub const EMBARGO_DAYS: u32 = 14;
+
+/// Coq theorem citation attached to every `bpb_samples` row.
+pub const COQ_THEOREM_ID: &str = "alpha_phi_phi_cubed";
+
+// ─────────────── spec_envelope ───────────────
+
+/// Spec envelope — every knob the Python entry reads via env vars.
+///
+/// Defaults match the arXiv paper's reference config.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct E2eTttEnv {
+    /// `TTT_INNER_STEPS` — inner-loop steps per chunk (paper: 4).
+    pub inner_steps: u32,
+    /// `TTT_LR_INNER` — inner learning rate, φ-band-compatible
+    /// (paper: 1e-3).
+    pub lr_inner: f64,
+    /// `TTT_CHUNK_LEN` — chunk length in tokens (paper: 512).
+    pub chunk_len: u32,
+}
+
+impl Default for E2eTttEnv {
+    fn default() -> Self {
+        Self {
+            inner_steps: 4,
+            lr_inner: 1e-3,
+            chunk_len: 512,
+        }
+    }
+}
+
+impl E2eTttEnv {
+    /// Convert to the `Vec<(EnvVar, EnvValue)>` shape that `AlgorithmSpec`
+    /// expects, preserving the paper's ordering.
+    pub fn to_env_vars(&self) -> Vec<(EnvVar, EnvValue)> {
+        vec![
+            (
+                EnvVar::new("TTT_INNER_STEPS"),
+                EnvValue::new(self.inner_steps.to_string()),
+            ),
+            (
+                EnvVar::new("TTT_LR_INNER"),
+                EnvValue::new(format!("{}", self.lr_inner)),
+            ),
+            (
+                EnvVar::new("TTT_CHUNK_LEN"),
+                EnvValue::new(self.chunk_len.to_string()),
+            ),
+        ]
+    }
+
+    /// Special case: when `TTT_INNER_STEPS=0`, the trainer MUST degrade
+    /// into the merged baseline byte-for-byte (pattern from PR #2059
+    /// `baseline_equivalence.py`). Returns the zero-inner-steps config
+    /// used by the baseline-equivalence verifier.
+    pub fn baseline_equivalence() -> Self {
+        Self {
+            inner_steps: 0,
+            ..Self::default()
+        }
+    }
+}
+
+// ─────────────── verifier ───────────────
+
+/// Compute the SHA-256 of an entry script's bytes.
+pub fn sha256_bytes(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&h.finalize());
+    out
+}
+
+/// Build the canonical [`AlgorithmSpec`] for e2e-ttt.
+///
+/// `entry_hash` MUST be the SHA-256 of the pinned `train_gpt.py`
+/// source. SR-02 `TrainerRunner` calls [`Verifier::preflight`] before
+/// spawning and refuses to run on a hash mismatch.
+pub fn build_spec(entry_hash: EntryHash, env: &E2eTttEnv) -> AlgorithmSpec {
+    AlgorithmSpec {
+        algorithm_id: AlgorithmId::new(),
+        name: "e2e-ttt".into(),
+        entry_path: PathBuf::from(ENTRY_PATH),
+        entry_hash,
+        env: env.to_env_vars(),
+        golden_state_hash: None,
+        theorem: Some(COQ_THEOREM_ID.into()),
+    }
+}
+
+/// Outcome of a pre-flight check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum VerifierOutcome {
+    /// Hash + env are valid; safe to spawn.
+    Ok,
+    /// `actual_hash` does not equal `spec.entry_hash`.
+    HashMismatch {
+        /// Hex of the hash the spec expected.
+        expected_hex: String,
+        /// Hex of the hash we actually observed.
+        actual_hex: String,
+    },
+    /// `entry_path` lives INSIDE `crates/` (R-L6-PURE-007 violation).
+    PathUnderCrates {
+        /// Offending path.
+        path: String,
+    },
+    /// Env-var sanity: `TTT_INNER_STEPS` must be 0..=16; `TTT_CHUNK_LEN`
+    /// must be a positive power of two up to 2048.
+    InvalidEnv {
+        /// Free-form reason.
+        reason: String,
+    },
+}
+
+/// Pure stateless verifier.
+pub struct Verifier;
+
+impl Verifier {
+    /// Full pre-flight check. Called by SR-02 `TrainerRunner` before
+    /// spawning the Python trainer.
+    pub fn preflight(
+        spec: &AlgorithmSpec,
+        env: &E2eTttEnv,
+        actual_entry_bytes: &[u8],
+    ) -> VerifierOutcome {
+        // ── Path check ──
+        let path_str = spec.entry_path.to_string_lossy();
+        if path_str.starts_with("crates/") || path_str.contains("/crates/") {
+            return VerifierOutcome::PathUnderCrates {
+                path: path_str.into_owned(),
+            };
+        }
+
+        // ── Hash check ──
+        let actual = sha256_bytes(actual_entry_bytes);
+        if !spec.verify_hash(&actual) {
+            return VerifierOutcome::HashMismatch {
+                expected_hex: hex::encode(spec.entry_hash.as_bytes()),
+                actual_hex: hex::encode(actual),
+            };
+        }
+
+        // ── Env sanity ──
+        if env.inner_steps > 16 {
+            return VerifierOutcome::InvalidEnv {
+                reason: format!(
+                    "TTT_INNER_STEPS must be 0..=16, got {}",
+                    env.inner_steps
+                ),
+            };
+        }
+        if env.chunk_len == 0
+            || env.chunk_len > 2048
+            || !env.chunk_len.is_power_of_two()
+        {
+            return VerifierOutcome::InvalidEnv {
+                reason: format!(
+                    "TTT_CHUNK_LEN must be a positive power of two up to 2048, got {}",
+                    env.chunk_len
+                ),
+            };
+        }
+        if !env.lr_inner.is_finite() || env.lr_inner <= 0.0 || env.lr_inner > 1e-1 {
+            return VerifierOutcome::InvalidEnv {
+                reason: format!(
+                    "TTT_LR_INNER must be finite in (0, 0.1], got {}",
+                    env.lr_inner
+                ),
+            };
+        }
+
+        VerifierOutcome::Ok
+    }
+}
+
+// ─────────────── gate ───────────────
+
+/// Gate verdict for a 3-seed sweep against the #1837 baseline.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "verdict", rename_all = "snake_case")]
+pub enum GateVerdict {
+    /// Achieved — 3-seed mean is below `TARGET_VAL_BPB`.
+    Win {
+        /// 3-seed mean val_bpb.
+        mean_val_bpb: f64,
+        /// Margin below target (target - mean).
+        margin: f64,
+    },
+    /// Did not beat baseline — 3-seed mean is ≥ target.
+    HonestNotYet {
+        /// 3-seed mean val_bpb.
+        mean_val_bpb: f64,
+        /// Gap above target (mean - target).
+        gap: f64,
+    },
+}
+
+/// Evaluate a 3-seed sweep against the baseline.
+///
+/// Panics if `seed_bpbs.len() != 3` (contract — the sweep is always 3
+/// Fibonacci seeds).
+pub fn evaluate_gate(seed_bpbs: [f64; 3]) -> GateVerdict {
+    let mean = (seed_bpbs[0] + seed_bpbs[1] + seed_bpbs[2]) / 3.0;
+    if mean < TARGET_VAL_BPB {
+        GateVerdict::Win {
+            mean_val_bpb: mean,
+            margin: TARGET_VAL_BPB - mean,
+        }
+    } else {
+        GateVerdict::HonestNotYet {
+            mean_val_bpb: mean,
+            gap: mean - TARGET_VAL_BPB,
+        }
+    }
+}
+
+// ─────────────── tests ───────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn script(kind: &str) -> Vec<u8> {
+        match kind {
+            "a" => b"# e2e-ttt variant A\nprint('hi')\n".to_vec(),
+            "b" => b"# e2e-ttt variant B\nprint('hi')\n".to_vec(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn spec_for(bytes: &[u8], env: &E2eTttEnv) -> AlgorithmSpec {
+        build_spec(EntryHash(sha256_bytes(bytes)), env)
+    }
+
+    // ── constants ──
+
+    #[test]
+    fn target_val_bpb_matches_issue() {
+        assert_eq!(TARGET_VAL_BPB, 1.07063);
+    }
+
+    #[test]
+    fn fibonacci_seeds_match_spec() {
+        // F_17 = 1597, F_18 = 2584, F_19 = 4181
+        assert_eq!(FIBONACCI_SEEDS, [1597, 2584, 4181]);
+        // Fibonacci identity: F_n = F_{n-1} + F_{n-2}
+        assert_eq!(FIBONACCI_SEEDS[1], 987 + 1597); // F_17 + F_16
+        assert_eq!(FIBONACCI_SEEDS[2], FIBONACCI_SEEDS[0] + FIBONACCI_SEEDS[1]);
+    }
+
+    #[test]
+    fn entry_path_outside_crates() {
+        // R-L6-PURE-007: ENTRY_PATH MUST NOT live inside crates/.
+        assert!(!ENTRY_PATH.starts_with("crates/"));
+        assert!(!ENTRY_PATH.contains("/crates/"));
+    }
+
+    #[test]
+    fn embargo_window_is_14_days() {
+        assert_eq!(EMBARGO_DAYS, 14);
+    }
+
+    // ── env ──
+
+    #[test]
+    fn env_default_matches_paper() {
+        let e = E2eTttEnv::default();
+        assert_eq!(e.inner_steps, 4);
+        assert_eq!(e.lr_inner, 1e-3);
+        assert_eq!(e.chunk_len, 512);
+    }
+
+    #[test]
+    fn env_to_env_vars_preserves_order() {
+        let e = E2eTttEnv::default();
+        let v = e.to_env_vars();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[0].0.as_str(), "TTT_INNER_STEPS");
+        assert_eq!(v[1].0.as_str(), "TTT_LR_INNER");
+        assert_eq!(v[2].0.as_str(), "TTT_CHUNK_LEN");
+    }
+
+    #[test]
+    fn env_baseline_equivalence_zero_inner_steps() {
+        let e = E2eTttEnv::baseline_equivalence();
+        assert_eq!(e.inner_steps, 0);
+        assert_eq!(e.chunk_len, 512);
+    }
+
+    // ── verifier ──
+
+    #[test]
+    fn verifier_ok_path() {
+        let bytes = script("a");
+        let env = E2eTttEnv::default();
+        let spec = spec_for(&bytes, &env);
+        assert_eq!(Verifier::preflight(&spec, &env, &bytes), VerifierOutcome::Ok);
+    }
+
+    #[test]
+    fn verifier_rejects_hash_mismatch() {
+        let bytes_a = script("a");
+        let bytes_b = script("b");
+        let env = E2eTttEnv::default();
+        let spec = spec_for(&bytes_a, &env); // spec pinned to A
+        match Verifier::preflight(&spec, &env, &bytes_b) {
+            VerifierOutcome::HashMismatch { expected_hex, actual_hex } => {
+                assert_ne!(expected_hex, actual_hex);
+                assert_eq!(expected_hex.len(), 64);
+            }
+            other => panic!("expected HashMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verifier_rejects_path_under_crates() {
+        let bytes = script("a");
+        let env = E2eTttEnv::default();
+        let mut spec = spec_for(&bytes, &env);
+        spec.entry_path = PathBuf::from("crates/trios-algorithm-arena/bad/train.py");
+        assert!(matches!(
+            Verifier::preflight(&spec, &env, &bytes),
+            VerifierOutcome::PathUnderCrates { .. }
+        ));
+    }
+
+    #[test]
+    fn verifier_rejects_inner_steps_too_high() {
+        let bytes = script("a");
+        let env = E2eTttEnv {
+            inner_steps: 17,
+            ..E2eTttEnv::default()
+        };
+        let spec = spec_for(&bytes, &env);
+        assert!(matches!(
+            Verifier::preflight(&spec, &env, &bytes),
+            VerifierOutcome::InvalidEnv { .. }
+        ));
+    }
+
+    #[test]
+    fn verifier_rejects_non_power_of_two_chunk() {
+        let bytes = script("a");
+        let env = E2eTttEnv {
+            chunk_len: 600,
+            ..E2eTttEnv::default()
+        };
+        let spec = spec_for(&bytes, &env);
+        assert!(matches!(
+            Verifier::preflight(&spec, &env, &bytes),
+            VerifierOutcome::InvalidEnv { .. }
+        ));
+    }
+
+    #[test]
+    fn verifier_rejects_zero_chunk_len() {
+        let bytes = script("a");
+        let env = E2eTttEnv {
+            chunk_len: 0,
+            ..E2eTttEnv::default()
+        };
+        let spec = spec_for(&bytes, &env);
+        assert!(matches!(
+            Verifier::preflight(&spec, &env, &bytes),
+            VerifierOutcome::InvalidEnv { .. }
+        ));
+    }
+
+    #[test]
+    fn verifier_rejects_non_finite_lr() {
+        let bytes = script("a");
+        let env = E2eTttEnv {
+            lr_inner: f64::NAN,
+            ..E2eTttEnv::default()
+        };
+        let spec = spec_for(&bytes, &env);
+        assert!(matches!(
+            Verifier::preflight(&spec, &env, &bytes),
+            VerifierOutcome::InvalidEnv { .. }
+        ));
+    }
+
+    // ── spec ──
+
+    #[test]
+    fn build_spec_attaches_theorem_id() {
+        let bytes = script("a");
+        let env = E2eTttEnv::default();
+        let spec = spec_for(&bytes, &env);
+        assert_eq!(spec.theorem.as_deref(), Some(COQ_THEOREM_ID));
+        assert_eq!(spec.name, "e2e-ttt");
+    }
+
+    #[test]
+    fn build_spec_entry_path_is_pinned_constant() {
+        let bytes = script("a");
+        let env = E2eTttEnv::default();
+        let spec = spec_for(&bytes, &env);
+        assert_eq!(spec.entry_path, PathBuf::from(ENTRY_PATH));
+    }
+
+    // ── gate ──
+
+    #[test]
+    fn gate_win_below_target() {
+        match evaluate_gate([1.05, 1.06, 1.07]) {
+            GateVerdict::Win { mean_val_bpb, margin } => {
+                assert!(mean_val_bpb < TARGET_VAL_BPB);
+                assert!((margin - (TARGET_VAL_BPB - mean_val_bpb)).abs() < 1e-9);
+            }
+            other => panic!("expected Win, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn gate_honest_not_yet_at_or_above_target() {
+        let v = evaluate_gate([1.07063, 1.08, 1.09]);
+        assert!(matches!(v, GateVerdict::HonestNotYet { .. }));
+    }
+
+    #[test]
+    fn gate_honest_not_yet_exact_target() {
+        let v = evaluate_gate([TARGET_VAL_BPB; 3]);
+        assert!(
+            matches!(v, GateVerdict::HonestNotYet { .. }),
+            "mean == target must be HonestNotYet (strict inequality)"
+        );
+    }
+
+    #[test]
+    fn gate_verdict_serialises_tagged_kind() {
+        let v = evaluate_gate([1.0, 1.0, 1.0]);
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(s.contains("\"verdict\""));
+        assert!(s.contains("\"win\""));
+    }
+}

--- a/crates/trios-algorithm-arena/src/lib.rs
+++ b/crates/trios-algorithm-arena/src/lib.rs
@@ -8,3 +8,8 @@
 //! re-exports.
 
 pub use trios_algorithm_arena_sr_alg_00::*;
+pub use trios_algorithm_arena_sr_alg_03::{
+    build_spec, evaluate_gate, sha256_bytes, E2eTttEnv, GateVerdict, Verifier,
+    VerifierOutcome, COQ_THEOREM_ID, EMBARGO_DAYS, ENTRY_PATH, FIBONACCI_SEEDS,
+    TARGET_VAL_BPB,
+};


### PR DESCRIPTION
## SR-ALG-03 — e2e-ttt (spec + verifier ring) ⭐ WIN lane

Closes #457 (spec + verifier portion) · Part of #446
Blocked-by: SR-ALG-00 ✅ (merged `5128056401`)

**Soul-name:** `Bit Per Byte Hunter` · **Codename:** `LEAD` · **Tier:** 🥈 Silver
**WIN target:** 3-seed mean `val_bpb < 1.07063`

### Honest scope (R5)

This PR ships the **Rust spec + verifier** ring. The GPU 3-seed sweep on F₁₇/F₁₈/F₁₉ that produces `val_bpb < 1.07063` is a **follow-up PR** through SR-02 `TrainerRunner` + a BR-OUTPUT GPU harness. SR-ALG-03 pins every constant the follow-up needs so that PR doesn't have to re-derive anything.

### What landed

| Const | Value |
|---|---|
| `TARGET_VAL_BPB` | `1.07063` |
| `FIBONACCI_SEEDS` | `[F₁₇=1597, F₁₈=2584, F₁₉=4181]` |
| `ENTRY_PATH` | `"parameter-golf/records/track_10min_16mb/e2e-ttt/train_gpt.py"` (OUTSIDE `crates/`, R-L6-PURE-007) |
| `EMBARGO_DAYS` | `14` |
| `COQ_THEOREM_ID` | `"alpha_phi_phi_cubed"` (attached to `bpb_samples` rows) |

Types:
- `E2eTttEnv { inner_steps=4, lr_inner=1e-3, chunk_len=512 }` — arXiv:2512.23675 paper defaults
- `E2eTttEnv::baseline_equivalence()` — `inner_steps=0`, pattern from `parameter-golf#2059 baseline_equivalence.py`
- `build_spec(entry_hash, env) -> AlgorithmSpec`
- `sha256_bytes(&[u8]) -> [u8; 32]`
- `Verifier::preflight(spec, env, actual_bytes) -> VerifierOutcome`
- `evaluate_gate([f64; 3]) -> GateVerdict::{Win, HonestNotYet}` — **strict** `mean < TARGET_VAL_BPB`

### Tests (20/20 GREEN)

| Group | Tests |
|---|---|
| Constants | 4 (target, Fibonacci identity, path outside `crates/`, embargo) |
| Env | 3 (paper defaults, order, baseline-equivalence) |
| Verifier | 7 (Ok + 6 rejection paths) |
| Spec builder | 2 (theorem id attached, path pinned) |
| Gate | 4 (win, not-yet, exact-equal ⇒ not-yet, serde tag) |

### What this ring does NOT do (follow-up PR)

| Out of scope | Lives in |
|---|---|
| GPU spawn of `train_gpt.py` | SR-02 `TrainerRunner` (#454) |
| 3-seed sweep F₁₇/F₁₈/F₁₉ | BR-OUTPUT GPU harness |
| Writing `bpb_samples` rows with `algorithm="e2e-ttt"`, `entry_hash`, `coq_theorem` | SR-03 `BpbWriter` (already in main) |
| `bpb_samples.embargo_until` | BR-OUTPUT writer policy |
| `make verify` smoke (CPU, 1 step) | Out-of-tree harness |

### Compliance

L1 ✓ · L3 ✓ · L4 ✓ · L6 ✓ · L11 ✓ (soul-name claimed before any future `train_gpt.py` invocation) · L13 ✓ · L14 ✓ · R-L6-PURE-007 ✓ (no `.py` in this crate) · R-RING-DEP-002 ✓ · R-RING-FACADE-001 ✓ · I5 ✓

🌻 `α_φ = φ⁻³ / 2` · WIN target `1.07063`

Agent: Bit-Per-Byte-Hunter
