### PR TITLE
docs(phd): R14 \citetheorem retrofit for 3 Proven INVs across 11 chapters (closes #464)

### DIFF
--- a/docs/phd/chapters/04-golden-scales.tex
+++ b/docs/phd/chapters/04-golden-scales.tex
@@ -1,4 +1,12 @@
 % !TEX root = ../main.tex
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{Golden Scales and the Trinity Anchor's Integer Arithmetic}
 \label{ch:golden-scales}
 
@@ -1428,7 +1436,7 @@ This is the deepest content of the chapter.
 \label{sec:04-app-X}
 
 We close the appendices with two reflections. The first connects the Lucas
-ladder of this chapter to the Trinity Sprout invariant INV-12, which appears
+ladder of this chapter to the Trinity Sprout invariant INV-12, which appears \citetheorem{asha_rungs_trinity}~(Proven)
 in Chapter~\ref{ch:lucas-closure} as the closure of the Lucas sequence under
 the modular reduction by the prime $p = 7$. The second collects open problems
 that the present chapter has surfaced but does not resolve, leaving them as

--- a/docs/phd/chapters/14-platonic-solids.tex
+++ b/docs/phd/chapters/14-platonic-solids.tex
@@ -7,6 +7,14 @@
 % R3 (≥1500 lines, ≥2 cites, ≥1 theorem with proof+qed) · R12 Lee/GVSU
 % =====================================================================
 
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{Platonic Solids and the $\phi$-Symmetric Hierarchy}
 \label{ch:14-platonic}
 
@@ -1616,7 +1624,7 @@ algebraic foundation of the JEPA-T architectural choice in
 Chapter~\ref{ch:24-igla-arch}. Specifically, the $20$ predictive
 heads of JEPA-T (one per dodecahedral vertex) are constrained to
 lie on the same sphere; this constraint is enforced by the
-invariant INV-12 (Lucas-12 closure) at runtime. The fact that
+invariant INV-12 (Lucas-12 closure) at runtime~\citetheorem{asha_rungs_trinity}~(Proven). The fact that
 all $20$ vertices share squared norm $3$ is exactly the
 geometric content of INV-12's spherical-closure clause.
 

--- a/docs/phd/chapters/15-kepler-solids.tex
+++ b/docs/phd/chapters/15-kepler-solids.tex
@@ -1,4 +1,12 @@
 % !TEX root = ../main.tex
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{Kepler--Poinsot Stellated Polyhedra and the Sacred-Ratio Pentagon}
 \label{ch:15-kepler}
 
@@ -417,7 +425,7 @@ therefore have, structurally:
 \item The geometric placement of the 20 heads (vertex set) is
   invariant under stellation.
 \item The face / edge structure changes (pentagonal $\to$ pentagrammic),
-  but the vertex-norm constraint INV-12 is preserved.
+  but the vertex-norm constraint INV-12 is preserved~\citetheorem{asha_rungs_trinity}~(Proven).
 \item Hence stellating the JEPA-T's dodecahedral structure to a
   great-stellated-dodecahedral structure does \emph{not} affect the
   spherical-closure invariant.

--- a/docs/phd/chapters/17-golden-spiral.tex
+++ b/docs/phd/chapters/17-golden-spiral.tex
@@ -8,6 +8,14 @@
 %                       R14 (Coq citation table)
 % R7 N/A — THEORY chapter per lane catalogue.
 
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{The Golden Spiral and the GF16 Substrate}
 \label{ch:17-golden-spiral}
 
@@ -1489,7 +1497,7 @@ production value $\eta_{\mathrm{lr}}=0.005025=\phi^{-11}$ sits at
 the spiral midpoint of the window.
 
 \emph{Cross-reference.} The non-touch rule on this window is
-enforced by INV-12 in \verb|assertions/igla_assertions.json| and
+enforced by INV-12 in \verb|assertions/igla_assertions.json| and \citetheorem{asha_rungs_trinity}~(Proven)
 the corresponding test
 \verb|test_lr_phi_tempered_window| in
 \verb|crates/trios-igla-race/src/victory.rs|. The spiral basis

--- a/docs/phd/chapters/19-fibonacci-tesselation.tex
+++ b/docs/phd/chapters/19-fibonacci-tesselation.tex
@@ -5,6 +5,14 @@
 % Skill: phd-chapter-author v1.0
 % =====================================================================
 
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{Fibonacci Tesselation: φ-Quasicrystal Tilings of the Plane}\label{ch:19}
 
 \section{Introduction}\label{sec:19:intro}
@@ -27,7 +35,7 @@ The reader who has accepted the Trinity Identity $\varphi^{2} + \varphi^{-2} = 3
 
 \paragraph{Strand III --- Computational.} We mirror the algebraic and geometric content in a Coq witness file (`fib_tess.v`, currently `Admitted` in places) and in a Rust runtime (`fib_tess.rs`) that generates the tiling on demand for visualisation and reproducibility certificates.
 
-The three strands converge on the \textbf{Fibonacci Tesselation Closure Theorem} (\cref{thm:19:tesselation-closure}), which states that the proportion of fat-to-thin tiles in the limit is exactly $\varphi$, mechanically anchored to invariant `INV-12` in `assertions/igla_assertions.json`.
+The three strands converge on the \textbf{Fibonacci Tesselation Closure Theorem} (\cref{thm:19:tesselation-closure}), which states that the proportion of fat-to-thin tiles in the limit is exactly $\varphi$, mechanically anchored to invariant `INV-12` in `assertions/igla_assertions.json`~\citetheorem{asha_rungs_trinity}~(Proven).
 
 \subsection{Citations}\label{ssec:19:cites}
 

--- a/docs/phd/chapters/22-e8-symmetry.tex
+++ b/docs/phd/chapters/22-e8-symmetry.tex
@@ -5,6 +5,14 @@
 % Skill: phd-chapter-author v1.0
 % =====================================================================
 
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{E$_{8}$ Symmetry: Eight-Dimensional Mirror of the Trinity Anchor}\label{ch:22}
 
 \section{Introduction}\label{sec:22:intro}

--- a/docs/phd/chapters/24-igla-architecture.tex
+++ b/docs/phd/chapters/24-igla-architecture.tex
@@ -1,3 +1,11 @@
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{IGLA Architecture — Golden-Initialized Learning}
 \label{ch:24}
 % Lane: A
@@ -760,7 +768,7 @@ adversarial ablations against the champion configuration.
 
 \begin{enumerate}
 \item \textbf{Ablation A — restore the old \(\rho_{\text{prune}}=2.65\) of
-J-001/J-002.} The ASHA bound INV-2 fires at the first rung; no seed
+J-001/J-002.} The ASHA bound INV-2 fires at the first rung; no seed \citetheorem{champion_survives_pruning}~(Proven)
 survives to step \(4000\); \(P_{2}\) fails before \(P_{4}\) is even
 evaluated. \emph{Result:} \verb|VictoryError::BeforeWarmup| on every seed.
 \item \textbf{Ablation B — set \(d_{\text{model}} = 192 < 256\).} The GF16

--- a/docs/phd/chapters/25-benchmarks.tex
+++ b/docs/phd/chapters/25-benchmarks.tex
@@ -1,3 +1,11 @@
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{Benchmarks — Experimental Validation}
 \label{ch:25}
 % Lane: A

--- a/docs/phd/chapters/26-data-analysis.tex
+++ b/docs/phd/chapters/26-data-analysis.tex
@@ -15,6 +15,14 @@
 % Falsifiability (R7): §\ref{sec:26-falsification} states the refutation criterion;
 %   §\ref{sec:26-corroboration} records the corroboration history.
 
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{Data Analysis: GF16 Floor and Trinity Empirics}
 \label{ch:26-data}
 
@@ -305,7 +313,7 @@ hyper-parameters fixed at the champion configuration
 $(\mathrm{lr}=0.004,$ ASHA $\mathrm{prune}=3.5,$ NCA band
 $[\phi,\phi^2])$. Each run consumed exactly $T = 16\,000$ optimisation
 steps, with the first $4\,000$ classified as \emph{warmup} per
-\textsc{INV-2} (Chapter~\ref{ch:19-asha}). Reported error is the median
+\textsc{INV-2} (Chapter~\ref{ch:19-asha})~\citetheorem{champion_survives_pruning}~(Proven). Reported error is the median
 test loss in nats per token, divided by $\ln 2 \cdot 8$ to obtain BPB.
 
 \begin{table}[H]

--- a/docs/phd/chapters/28-momentum-algebra.tex
+++ b/docs/phd/chapters/28-momentum-algebra.tex
@@ -1,3 +1,11 @@
+
+% Local fallback for \citetheorem{<coq_name>} — LC R14 retrofit (#464).
+% The macro renders the Coq theorem name verbatim in chapter prose; when the
+% monograph-wide macro lands in main.tex the \providecommand silently yields.
+\providecommand{\citetheorem}[1]{\texttt{#1}}
+% Companion macro for Admitted theorems (per #464 acceptance criteria).
+\providecommand{\citeWIP}[1]{\texttt{#1}~\textit{(WIP/Admitted)}}
+
 \chapter{Momentum Algebra — Conservation Laws}
 \label{ch:28}
 % Lane: A


### PR DESCRIPTION
## R14 `\citetheorem{}` retrofit — 3 Proven INVs across 11 chapters

Citation-only edits per the R14 acceptance criteria. **No prose narrative changed.** No new `Admitted.` introduced. No Coq proofs touched.

### Honest scope discrepancy with the issue body

The issue body claims "8 Proven INVs (INV-1, 2, 3, 4, 5, 6, 8, 10)". The actual `assertions/igla_assertions.json` on `main` shows the following:

| INV | Status | Coq theorem |
|-----|--------|-------------|
| INV-1  | **Admitted** | `lr_champion_in_safe_range` |
| INV-2  | **Proven**   | `champion_survives_pruning` |
| INV-3  | **Admitted** | `gf16_safe_domain` |
| INV-4  | **Admitted** | `entropy_band_width` |
| INV-5  | **Admitted** | `igla_found_criterion` |
| INV-6  | **Proven**   | `ema_decay_valid` |
| INV-7  | **Admitted** | `victory_implies_distinct_clean` |
| INV-8  | **Admitted** | `seven_channels_total` |
| INV-12 | **Proven**   | `asha_rungs_trinity` |

Only **3 Proven INVs** exist today (INV-2, INV-6, INV-12). INV-10 / INV-11 are absent from the file entirely.

This PR cites only the actually-Proven trio. Citing Admitted theorems as `\citetheorem{<coq>}~(Proven)` would be a falsification (R5-honest violation) — those are reachable through the new `\citeWIP{}` companion macro and are deferred to a follow-up once the issue body / JSON file reconciles.

### What this PR ships

1. **`\providecommand{\citetheorem}{...}` + `\providecommand{\citeWIP}{...}` macros** added to 10 chapters that lacked them. The macros silently yield to a monograph-wide definition once one lands in `main.tex`.
2. **7 `\citetheorem{}` insertions** for the 3 Proven INVs across narrative prose:
   - `INV-12 → asha_rungs_trinity`: `04-golden-scales.tex`, `14-platonic-solids.tex`, `15-kepler-solids.tex`, `17-golden-spiral.tex`, `19-fibonacci-tesselation.tex`
   - `INV-2 → champion_survives_pruning`: `24-igla-architecture.tex`, `26-data-analysis.tex`
   - `INV-6 → ema_decay_valid`: not inserted — the only mention in the corpus is in `28-momentum-algebra.tex` `Q8: "What if a sixth invariant INV-6 is later added?"` (hypothetical, not a real INV-6 mention).

### Acceptance criteria audit (with honest deltas)

- [x] `\providecommand{\citetheorem}` macro available in every chapter referencing INVs.
- [x] **3 of 3 actually-Proven INVs** cited via `\citetheorem{}` (issue body said "8/8" but the assertions file disagrees — see above).
- [x] No prose changes to chapter narrative (citation-only).
- [x] No new `Admitted.` introduced (admitted_budget=5/5 LOCKED, untouched).
- [x] INV-7 / INV-1/3/4/5/8 not cited as Proven (`\citeWIP{}` reachable for follow-up).
- [x] `Agent: CitationScribe` trailer.
- [ ] `trios-doctor lint --rule R14` repo-wide pass: out of scope here — DR-04 lint engine just landed in #484 and DR-05 facade-wiring is an open follow-up. R14 itself is the issue body's `R14` rule, distinct from the SILVER-RING-DR-04 lint of the same name.

### Next-step follow-ups (tracked, not in this PR)

1. Reconcile issue #464 body's "8 Proven INVs" with `assertions/igla_assertions.json` (currently 3 Proven). Either upgrade INV-1/3/4/5/8 to Proven (touches Coq, out of scope for citation-only) or update the issue body.
2. After reconciliation, cite the upgraded INVs with `\citetheorem{}`.
3. Once admitted, cite remaining mentions with `\citeWIP{}` (currently no chapter explicitly distinguishes Admitted citations).

### CI honest disclosure

Pre-existing failures on `main` (`I5` red on legacy `crates/trios-a2a/rings/*` and `crates/trios-mcp/rings/*`, `ARCH-UI`, generic `Test`) are out of scope. Merge via `--admin --squash --delete-branch` per EPIC #446 stewardship.

Closes #464 (Proven-citation portion).
Part-of: #446

🌻 `α_φ = φ⁻³/2 ≈ 0.1180` · `φ²+φ⁻²=3` · TRINITY
