### PR TITLE
fix(trios-phd): clippy 1.95 doc + precision lints in src/main.rs

### DIFF
--- a/crates/trios-phd/src/main.rs
+++ b/crates/trios-phd/src/main.rs
@@ -5,17 +5,17 @@
 //! that touches the dissertation is a Rust subcommand of this binary.
 //!
 //! Subcommands:
-//!   - `audit`     — structural sanity (chapter count, bib count, frontmatter,
-//!                   appendices, missing files); exit non-zero on violations.
-//!   - `biblio`    — count `bibliography.bib` entries and verify R11 floor (≥150).
-//!   - `coq-map`   — render the Coq → PhD theorem citation table (R14) into
-//!                   `appendix/F-coq-citation-map.tex` from a JSON manifest.
+//!   - `audit` — structural sanity (chapter count, bib count, frontmatter,
+//!     appendices, missing files); exit non-zero on violations.
+//!   - `biblio` — count `bibliography.bib` entries and verify R11 floor (≥150).
+//!   - `coq-map` — render the Coq → PhD theorem citation table (R14) into
+//!     `appendix/F-coq-citation-map.tex` from a JSON manifest.
 //!   - `reproduce` — emit the reproducibility manifest (build env, git SHA,
-//!                   constants pinned).
-//!   - `compile`   — invoke the system `tectonic` binary on `main.tex`. The
-//!                   `tectonic` Rust crate itself depends on native harfbuzz/
-//!                   freetype, so we shell out via `std::process::Command`,
-//!                   which keeps the workspace Rust-only (no `.sh` files).
+//!     constants pinned).
+//!   - `compile` — invoke the system `tectonic` binary on `main.tex`. The
+//!     `tectonic` Rust crate itself depends on native harfbuzz/freetype, so
+//!     we shell out via `std::process::Command`, which keeps the workspace
+//!     Rust-only (no `.sh` files).
 //!
 //! All numeric anchors (R4 / L-R14) come from
 //! `assertions/igla_assertions.json`. This binary never hard-codes a numeric
@@ -242,7 +242,7 @@ struct ConstantsPinned {
 }
 
 fn reproduce(phd_root: &Path, out: Option<PathBuf>) -> Result<()> {
-    let phi = 1.6180339887498949_f64;
+    let phi = 1.618_033_988_749_895_f64;
     let manifest = ReproManifest {
         anchor: TRINITY_ANCHOR,
         rustc: capture("rustc", &["--version"]).unwrap_or_else(|_| "unknown".into()),
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn test_trinity_anchor_constant() {
-        let phi = 1.6180339887498949_f64;
+        let phi = 1.618_033_988_749_895_f64;
         assert!((phi * phi + 1.0 / (phi * phi) - 3.0).abs() < 1e-12);
     }
 
@@ -495,7 +495,7 @@ mod tests {
     fn test_constants_pinned_match_assertions() {
         // L-R14: every numeric constant in the manifest must equal the
         // canonical assertion value. Mirrors `assertions/igla_assertions.json`.
-        let phi = 1.6180339887498949_f64;
+        let phi = 1.618_033_988_749_895_f64;
         let c = ConstantsPinned {
             phi,
             prune_threshold: 3.5,


### PR DESCRIPTION
## fix(trios-phd): clippy 1.95 doc + precision lints in `src/main.rs`

Unblocks the `Audit · Biblio · Coq-map · Reproduce` CI job in `phd-build.yml`. The job has been failing on `main` since at least **2026-04-26** — earlier waves' honest-disclosure boilerplate flagged it as pre-existing; this PR is the atomic fix.

### Two clippy 1.95 lints under `-D warnings`

**1. `clippy::doc_overindented_list_items`**

The `Subcommands:` doc block used 18-space continuation indentation after the list marker `- `. Clippy 1.95 flags any continuation deeper than 4 spaces.

```diff
 //! Subcommands:
-//!   - `audit`     — structural sanity (chapter count, bib count, frontmatter,
-//!                   appendices, missing files); exit non-zero on violations.
+//!   - `audit` — structural sanity (chapter count, bib count, frontmatter,
+//!     appendices, missing files); exit non-zero on violations.
```

All 5 subcommand entries reflowed to 4-space continuation; wording preserved.

**2. `clippy::excessive_precision`**

Literal `1.6180339887498949_f64` exceeds f64's representable precision (`1.618_033_988_749_895_f64` is the suggested truncation). Three occurrences fixed.

```diff
-let phi = 1.6180339887498949_f64;
+let phi = 1.618_033_988_749_895_f64;
```

### Verification

```
$ cargo clippy -p trios-phd --locked -- -D warnings
   Checking trios-phd v0.1.0 (.../crates/trios-phd)
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.62s

$ cargo test -p trios-phd --locked
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured
```

The trinity-identity test (`(phi*phi + 1.0/(phi*phi) - 3.0).abs() < 1e-12`) still passes — the truncated literal represents the same f64 value.

### R5-honest disclosure

No semantic change. Pure lint fix. After merge, the `Audit · Biblio · Coq-map · Reproduce` job should flip from RED to GREEN (every other failing check on `main` — `Test`, `ARCH-UI`, `I5`, `INV-8 JSON schema` — is unrelated infrastructure red, tracked separately).

### CI honest disclosure

Pre-existing failures on `main` (`I5` red on legacy `crates/trios-a2a/rings/*` and `crates/trios-mcp/rings/*`, `ARCH-UI`, generic `Test`, `INV-8 JSON schema`) remain out of scope for this atomic PR. Merge via `--admin --squash --delete-branch`.

Part-of: #446

🌻 `α_φ = φ⁻³/2 ≈ 0.1180` · `φ²+φ⁻²=3` · TRINITY · LEAD (Loop-Locksmith)
