### PR TITLE
docs(scarab-types): add missing TASK.md to SR-00..SR-04 (Wave-6 I5 debt)

### DIFF
--- a/crates/trios-scarab-types/rings/SR-00/TASK.md
+++ b/crates/trios-scarab-types/rings/SR-00/TASK.md
@@ -1,0 +1,43 @@
+# TASK — SR-00
+
+Closes #479 · Part of #446 · Soul: `Constitutional-Cartographer`
+
+## Acceptance
+
+- [x] SR-00 crate `trios-scarab-types-sr-00` created
+- [x] Public surface: Term + TermScarab
+- [x] Each variant implements `Display` + `as_markdown()`
+- [x] README.md with term taxonomy
+- [x] AGENTS.md with soul-name + mission
+- [x] RING.md with field table + dep budget
+- [x] `[dependencies]`: `serde` + SR-00 sibling only (R-RING-DEP-002)
+- [x] No `tokio`, no subprocess, no I/O (R-RING-DEP-002 Bronze-tier)
+- [x] No `.py` (R-L6-PURE-007)
+- [x] No `.sh` (R-L1-ECHO-006)
+- [x] `cargo clippy --all-targets -- -D warnings` → 0 warnings
+- [x] `cargo test --workspace` → all GREEN
+- [x] `Agent: Constitutional-Cartographer` trailer
+
+## R5-honest scope
+
+This ring is part of the parallel-execution foundation enabling 5
+agents to start simultaneously via `trinity-bootstrap --codename` (PR
+#469). Type-enforced anti-collision: each codename binds to one ring
+at compile time.
+
+16 Term variants (O-Type..LucasType) and TermScarab wrapper.
+
+## Out of scope (separate follow-ups)
+
+- Wire typed `Term` enum into `trinity-bootstrap` CLI (replaces
+  stringly-typed `--codename`). Tracked in
+  `.trinity/state/three-roads-479.json` R1.
+- Tag Tailscale mesh nodes with one TermScarab so ACL keys derive
+  from the typed scarab. Tracked R2.
+- SILVER-RING-DR-04 RuleEngine pass over the new rings. Tracked R3.
+
+## Wave-6 debt closure
+
+This file was missing in PR #488 (the original SR-00..04 landing in
+Wave 6) — the I5 CI gate flagged it on PR #495 and earlier wave
+status comments. This PR closes that debt.

--- a/crates/trios-scarab-types/rings/SR-01/TASK.md
+++ b/crates/trios-scarab-types/rings/SR-01/TASK.md
@@ -1,0 +1,43 @@
+# TASK — SR-01
+
+Closes #479 · Part of #446 · Soul: `Constitutional-Cartographer`
+
+## Acceptance
+
+- [x] SR-01 crate `trios-scarab-types-sr-01` created
+- [x] Public surface: LaneScarab + LaneScarabType
+- [x] Each variant implements `Display` + `as_markdown()`
+- [x] README.md with term taxonomy
+- [x] AGENTS.md with soul-name + mission
+- [x] RING.md with field table + dep budget
+- [x] `[dependencies]`: `serde` + SR-00 sibling only (R-RING-DEP-002)
+- [x] No `tokio`, no subprocess, no I/O (R-RING-DEP-002 Bronze-tier)
+- [x] No `.py` (R-L6-PURE-007)
+- [x] No `.sh` (R-L1-ECHO-006)
+- [x] `cargo clippy --all-targets -- -D warnings` → 0 warnings
+- [x] `cargo test --workspace` → all GREEN
+- [x] `Agent: Constitutional-Cartographer` trailer
+
+## R5-honest scope
+
+This ring is part of the parallel-execution foundation enabling 5
+agents to start simultaneously via `trinity-bootstrap --codename` (PR
+#469). Type-enforced anti-collision: each codename binds to one ring
+at compile time.
+
+O-Type + Two-Type binding for Lane-level agents.
+
+## Out of scope (separate follow-ups)
+
+- Wire typed `Term` enum into `trinity-bootstrap` CLI (replaces
+  stringly-typed `--codename`). Tracked in
+  `.trinity/state/three-roads-479.json` R1.
+- Tag Tailscale mesh nodes with one TermScarab so ACL keys derive
+  from the typed scarab. Tracked R2.
+- SILVER-RING-DR-04 RuleEngine pass over the new rings. Tracked R3.
+
+## Wave-6 debt closure
+
+This file was missing in PR #488 (the original SR-00..04 landing in
+Wave 6) — the I5 CI gate flagged it on PR #495 and earlier wave
+status comments. This PR closes that debt.

--- a/crates/trios-scarab-types/rings/SR-02/TASK.md
+++ b/crates/trios-scarab-types/rings/SR-02/TASK.md
@@ -1,0 +1,43 @@
+# TASK — SR-02
+
+Closes #479 · Part of #446 · Soul: `Constitutional-Cartographer`
+
+## Acceptance
+
+- [x] SR-02 crate `trios-scarab-types-sr-02` created
+- [x] Public surface: SoulScarab + SoulScarabType
+- [x] Each variant implements `Display` + `as_markdown()`
+- [x] README.md with term taxonomy
+- [x] AGENTS.md with soul-name + mission
+- [x] RING.md with field table + dep budget
+- [x] `[dependencies]`: `serde` + SR-00 sibling only (R-RING-DEP-002)
+- [x] No `tokio`, no subprocess, no I/O (R-RING-DEP-002 Bronze-tier)
+- [x] No `.py` (R-L6-PURE-007)
+- [x] No `.sh` (R-L1-ECHO-006)
+- [x] `cargo clippy --all-targets -- -D warnings` → 0 warnings
+- [x] `cargo test --workspace` → all GREEN
+- [x] `Agent: Constitutional-Cartographer` trailer
+
+## R5-honest scope
+
+This ring is part of the parallel-execution foundation enabling 5
+agents to start simultaneously via `trinity-bootstrap --codename` (PR
+#469). Type-enforced anti-collision: each codename binds to one ring
+at compile time.
+
+O-Type + Three-Type binding for Soul-level agents.
+
+## Out of scope (separate follow-ups)
+
+- Wire typed `Term` enum into `trinity-bootstrap` CLI (replaces
+  stringly-typed `--codename`). Tracked in
+  `.trinity/state/three-roads-479.json` R1.
+- Tag Tailscale mesh nodes with one TermScarab so ACL keys derive
+  from the typed scarab. Tracked R2.
+- SILVER-RING-DR-04 RuleEngine pass over the new rings. Tracked R3.
+
+## Wave-6 debt closure
+
+This file was missing in PR #488 (the original SR-00..04 landing in
+Wave 6) — the I5 CI gate flagged it on PR #495 and earlier wave
+status comments. This PR closes that debt.

--- a/crates/trios-scarab-types/rings/SR-03/TASK.md
+++ b/crates/trios-scarab-types/rings/SR-03/TASK.md
@@ -1,0 +1,43 @@
+# TASK — SR-03
+
+Closes #479 · Part of #446 · Soul: `Constitutional-Cartographer`
+
+## Acceptance
+
+- [x] SR-03 crate `trios-scarab-types-sr-03` created
+- [x] Public surface: GateScarab + GateScarabFourType
+- [x] Each variant implements `Display` + `as_markdown()`
+- [x] README.md with term taxonomy
+- [x] AGENTS.md with soul-name + mission
+- [x] RING.md with field table + dep budget
+- [x] `[dependencies]`: `serde` + SR-00 sibling only (R-RING-DEP-002)
+- [x] No `tokio`, no subprocess, no I/O (R-RING-DEP-002 Bronze-tier)
+- [x] No `.py` (R-L6-PURE-007)
+- [x] No `.sh` (R-L1-ECHO-006)
+- [x] `cargo clippy --all-targets -- -D warnings` → 0 warnings
+- [x] `cargo test --workspace` → all GREEN
+- [x] `Agent: Constitutional-Cartographer` trailer
+
+## R5-honest scope
+
+This ring is part of the parallel-execution foundation enabling 5
+agents to start simultaneously via `trinity-bootstrap --codename` (PR
+#469). Type-enforced anti-collision: each codename binds to one ring
+at compile time.
+
+O-Type + Four-Type binding for Gate-level (four) agents.
+
+## Out of scope (separate follow-ups)
+
+- Wire typed `Term` enum into `trinity-bootstrap` CLI (replaces
+  stringly-typed `--codename`). Tracked in
+  `.trinity/state/three-roads-479.json` R1.
+- Tag Tailscale mesh nodes with one TermScarab so ACL keys derive
+  from the typed scarab. Tracked R2.
+- SILVER-RING-DR-04 RuleEngine pass over the new rings. Tracked R3.
+
+## Wave-6 debt closure
+
+This file was missing in PR #488 (the original SR-00..04 landing in
+Wave 6) — the I5 CI gate flagged it on PR #495 and earlier wave
+status comments. This PR closes that debt.

--- a/crates/trios-scarab-types/rings/SR-04/TASK.md
+++ b/crates/trios-scarab-types/rings/SR-04/TASK.md
@@ -1,0 +1,43 @@
+# TASK — SR-04
+
+Closes #479 · Part of #446 · Soul: `Constitutional-Cartographer`
+
+## Acceptance
+
+- [x] SR-04 crate `trios-scarab-types-sr-04` created
+- [x] Public surface: GateScarab + GateScarabFiveType
+- [x] Each variant implements `Display` + `as_markdown()`
+- [x] README.md with term taxonomy
+- [x] AGENTS.md with soul-name + mission
+- [x] RING.md with field table + dep budget
+- [x] `[dependencies]`: `serde` + SR-00 sibling only (R-RING-DEP-002)
+- [x] No `tokio`, no subprocess, no I/O (R-RING-DEP-002 Bronze-tier)
+- [x] No `.py` (R-L6-PURE-007)
+- [x] No `.sh` (R-L1-ECHO-006)
+- [x] `cargo clippy --all-targets -- -D warnings` → 0 warnings
+- [x] `cargo test --workspace` → all GREEN
+- [x] `Agent: Constitutional-Cartographer` trailer
+
+## R5-honest scope
+
+This ring is part of the parallel-execution foundation enabling 5
+agents to start simultaneously via `trinity-bootstrap --codename` (PR
+#469). Type-enforced anti-collision: each codename binds to one ring
+at compile time.
+
+O-Type + Five-Type binding for Gate-level (five) agents.
+
+## Out of scope (separate follow-ups)
+
+- Wire typed `Term` enum into `trinity-bootstrap` CLI (replaces
+  stringly-typed `--codename`). Tracked in
+  `.trinity/state/three-roads-479.json` R1.
+- Tag Tailscale mesh nodes with one TermScarab so ACL keys derive
+  from the typed scarab. Tracked R2.
+- SILVER-RING-DR-04 RuleEngine pass over the new rings. Tracked R3.
+
+## Wave-6 debt closure
+
+This file was missing in PR #488 (the original SR-00..04 landing in
+Wave 6) — the I5 CI gate flagged it on PR #495 and earlier wave
+status comments. This PR closes that debt.


### PR DESCRIPTION
Closes I5 CI debt from Wave 6.

Surfaced by PR #495 review: the `I5 — каждое кольцо имеет README+TASK+AGENTS` gate flagged 5 missing TASK.md files in `crates/trios-scarab-types/rings/SR-00..SR-04` — my own oversight in PR #488.

This atomic PR adds the 5 TASK.md files with:
- Acceptance criteria (checked, reflects what already shipped)
- R5-honest scope statement
- Out-of-scope items pointing to `three-roads-479.json` R1/R2/R3
- Wave-6 debt closure note

No code changes. No semantic change. Pure I5 hygiene.

Part-of: #479
Part-of: #446
Agent: Loop-Locksmith