### PR TITLE
feat(#455): SR-MEM-05 episodic-bridge — lessons.rs + HDC ↔ KG (closes #455)

### DIFF
--- a/.trinity/state/three-roads-455.json
+++ b/.trinity/state/three-roads-455.json
@@ -1,0 +1,42 @@
+{
+  "issue": 455,
+  "epic": 446,
+  "ring": "GOLD IV / SR-MEM-05",
+  "crate": "trios-agent-memory-sr-mem-05",
+  "soul": "Loop-Locksmith",
+  "anchor": "phi^2 + phi^-2 = 3",
+  "depends_on": ["SR-MEM-00 (issue 449)", "SR-MEM-01 (issue 453)"],
+  "blocks": ["BR-OUTPUT(GOLD IV) full wiring (currently stub)"],
+  "three_roads": {
+    "road_a_full_wire": {
+      "name": "Full live wiring: Neon NOTIFY listener + sqlx + zig FFI",
+      "scope": "Spawn tokio task with sqlx::PgListener subscribed to LISTEN lessons_channel, FFI bindings to streaming_memory.zig exports, end-to-end live forward + reverse seed_replay against dev Neon DB",
+      "cost": "HIGH — pulls sqlx/runtime/native-tls into Silver tier (R-RING-DEP-002 violation), Zig FFI not yet stabilised, no dev Neon URL in CI",
+      "risk": "BREAKER — adds runtime I/O surface to Silver ring; will break R-RING-DEP-002 doctor rule; no integration test infra to verify NOTIFY plumbing",
+      "verdict": "REJECTED — violates Silver-tier purity; ZigFFI is not ready (issue's own AC marks 'TODO if Zig FFI not yet ready'); cannot smoke-test against Neon dev DB from sandbox"
+    },
+    "road_b_trait_contract": {
+      "name": "Trait-contract ring (matches SR-MEM-01 / SR-04 precedent)",
+      "scope": "Define LessonsSource + HdcReplaySource traits, Bridge<L,H,K: KgBackend> generic over them, in-memory mocks in tests, seed_replay reverse-direction implemented in pure Silver Rust against KgBackend recall_by_pattern, BR-IO ring (sibling) gets the concrete sqlx PgListener + Zig FFI shim later",
+      "cost": "LOW — same pattern as SR-MEM-01 KgBackend, SR-03 BpbSink, SR-04 GardenerSink; deps stay serde + tokio + thiserror + tracing + SR-MEM-00 + SR-MEM-01",
+      "risk": "LOW — proven pattern, all 8 prior rings ship this way, R5-honest disclosure of what's deferred to BR-IO",
+      "verdict": "CHOSEN — Silver-tier compliant, mirror of SR-MEM-01 architecture, full bidirectional contract + tests + reverse seed_replay implemented for real (not stubbed)"
+    },
+    "road_c_minimal_seed_only": {
+      "name": "seed_replay only, defer forwarder to next ring",
+      "scope": "Implement only the reverse direction (Bridge::seed_replay over KgBackend recall) and ship lessons-forwarder + HDC-forwarder as TODO",
+      "cost": "MED — leaves half the ring's contract unfulfilled, would burn another sub-issue",
+      "risk": "MED — issue AC explicitly lists Bridge::start subscribing to NOTIFY as required; partial impl invites scope creep",
+      "verdict": "REJECTED — issue AC requires the full bidirectional contract; we can ship the contract honestly even if the live BR-IO adapter is a sibling concern"
+    }
+  },
+  "chosen": "road_b_trait_contract",
+  "honest_disclosure_r5": [
+    "This ring ships the LessonsSource + HdcReplaySource traits + Bridge state machine.",
+    "The concrete sqlx PgListener + Zig FFI adapters are a sibling BR-IO ring concern (same precedent as trios_kg::KgClient sitting in BR-IO for SR-MEM-01).",
+    "seed_replay is implemented for real against any KgBackend (already exists in SR-MEM-01).",
+    "The forwarder side is implemented for real against any LessonsSource / HdcReplaySource that yields events; mock backends in tests prove the wiring.",
+    "Smoke against Neon dev DB cannot be run from this sandbox (no NEON_DATABASE_URL in CI) — issue's smoke-test AC is deferred to the BR-IO adapter PR with NEON_TEST_URL secret."
+  ],
+  "rules_honored": ["R1", "R5-honest", "R-RING-DEP-002", "R-L6-PURE-007", "L1", "L13", "L14", "I5"]
+}

--- a/crates/trios-agent-memory/Cargo.lock
+++ b/crates/trios-agent-memory/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "trios-agent-memory-br-output",
  "trios-agent-memory-sr-mem-00",
  "trios-agent-memory-sr-mem-01",
+ "trios-agent-memory-sr-mem-05",
 ]
 
 [[package]]
@@ -545,6 +546,21 @@ dependencies = [
  "tokio",
  "tracing",
  "trios-agent-memory-sr-mem-00",
+ "uuid",
+]
+
+[[package]]
+name = "trios-agent-memory-sr-mem-05"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trios-agent-memory-sr-mem-00",
+ "trios-agent-memory-sr-mem-01",
  "uuid",
 ]
 

--- a/crates/trios-agent-memory/Cargo.toml
+++ b/crates/trios-agent-memory/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 members = [
     "rings/SR-MEM-00",
     "rings/SR-MEM-01",
+    "rings/SR-MEM-05",
     "rings/BR-OUTPUT",
 ]
 
@@ -24,6 +25,7 @@ repository = "https://github.com/gHashTag/trios"
 [dependencies]
 trios-agent-memory-sr-mem-00 = { path = "rings/SR-MEM-00" }
 trios-agent-memory-sr-mem-01 = { path = "rings/SR-MEM-01" }
+trios-agent-memory-sr-mem-05 = { path = "rings/SR-MEM-05" }
 trios-agent-memory-br-output = { path = "rings/BR-OUTPUT" }
 
 [workspace.dependencies]

--- a/crates/trios-agent-memory/rings/SR-MEM-05/AGENTS.md
+++ b/crates/trios-agent-memory/rings/SR-MEM-05/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS — SR-MEM-05
+
+## Active soul
+
+- `Loop-Locksmith` — author, contract design, mock backends, reverse
+  `seed_replay` implementation.
+
+## Constitutional rules honoured
+
+- **R1** — pure Rust (no `.py` inside `crates/`, no `.sh`).
+- **R5-honest** — concrete sqlx + Zig FFI deferred to BR-IO ring; documented in README §Honest scope.
+- **R-RING-DEP-002** — Silver-tier deps only (`serde`, `serde_json`, `chrono`, `thiserror`, `tracing`, `tokio` runtime primitives, sibling SR-MEM rings).
+- **R-L6-PURE-007** — no `.py` files inside this ring.
+- **L1** — no `.sh` files in this ring.
+- **L13** (I-SCOPE) — only this ring is touched by the bridge contract definitions.
+- **L14** — every commit carries `Agent: Loop-Locksmith` trailer.
+- **I5** — README, TASK, AGENTS, RING, Cargo.toml, src/lib.rs all present.
+- **L21** — read-only forwarder on `lessons.rs`; `LessonsSource` trait
+  has no `&mut self` method, so a downstream impl cannot smuggle in a
+  write path through this contract.
+
+## Anchor
+
+`phi^2 + phi^-2 = 3`

--- a/crates/trios-agent-memory/rings/SR-MEM-05/Cargo.toml
+++ b/crates/trios-agent-memory/rings/SR-MEM-05/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "trios-agent-memory-sr-mem-05"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "SR-MEM-05 — episodic-bridge: lessons.rs + HDC ↔ KG bidirectional forwarder + seed_replay"
+publish = false
+
+[dependencies]
+trios-agent-memory-sr-mem-00 = { path = "../SR-MEM-00" }
+trios-agent-memory-sr-mem-01 = { path = "../SR-MEM-01" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+thiserror = "1.0"
+tracing = "0.1"
+# Async runtime primitives only (Silver-tier, no I/O drivers).
+# The concrete sqlx::PgListener and Zig FFI adapters live in a sibling
+# BR-IO ring; SR-MEM-05 stays mock-testable without spinning Neon.
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "time", "sync"] }
+uuid = { workspace = true }

--- a/crates/trios-agent-memory/rings/SR-MEM-05/README.md
+++ b/crates/trios-agent-memory/rings/SR-MEM-05/README.md
@@ -1,0 +1,105 @@
+# SR-MEM-05 — Episodic Bridge (lessons.rs + HDC ↔ KG)
+
+**Soul-name:** `Loop-Locksmith` · **Codename:** `LEAD` · **Tier:** 🥈 Silver
+
+> Closes #455 · Part of #446 · Anchor: `φ² + φ⁻² = 3`
+
+## Honest scope (R5)
+
+This ring ships the **bridge contract + state machine**, not the concrete
+`sqlx::PgListener` and Zig-FFI HDC reader. The trade-off mirrors SR-MEM-01:
+
+- Issue AC asks for `sqlx` (Neon NOTIFY) + Zig FFI (`streaming_memory.zig`).
+  Pulling `sqlx` (with `runtime-tokio-rustls`) and a Zig FFI shim into a
+  Silver ring would inherit native-TLS + the full Postgres surface and
+  violate `R-RING-DEP-002` (no I/O at Silver tier). The issue itself
+  acknowledges Zig FFI is not yet ready ("FFI binding marked TODO if
+  Zig FFI not yet ready").
+- Instead, SR-MEM-05 takes two trait objects:
+  - `LessonsSource` — yields `LessonRow` events (concrete sqlx PgListener
+    impl ships in a sibling BR-IO ring).
+  - `HdcReplaySource` — yields `HdcEpisode` events (concrete Zig-FFI impl
+    ships in a sibling BR-IO ring once `streaming_memory.zig` exports
+    stabilise).
+- Forward direction (`Bridge::run`) and reverse direction
+  (`Bridge::seed_replay`) are both implemented for real against the trait
+  objects + a `KgBackend` (re-used from SR-MEM-01). Mock backends in
+  tests prove every contract clause.
+
+The 4-clause contract from the issue is honoured 1:1:
+
+| Issue AC | Where it lives in this ring |
+|---|---|
+| Subscribe to Neon NOTIFY → forward as triple via SR-MEM-01 | `Bridge::run` over `LessonsSource::stream()` → `KgAdapter::remember_triple` |
+| HDC forwarder reads `streaming_memory.zig` | `Bridge::run` over `HdcReplaySource::stream()` |
+| Reverse: `seed_replay(&mut HdcMemory, lookback: Duration)` pulls KG triples back | `Bridge::seed_replay(&mut H: HdcSeedSink, lookback: Duration)` |
+| Read-only forwarder on `lessons.rs` (L21 immutability) | trait `LessonsSource::stream` returns `LessonRow` events; no write surface exists |
+
+## API
+
+```rust
+pub struct Bridge<L: LessonsSource, H: HdcReplaySource, B: KgBackend>;
+
+impl<L, H, B> Bridge<L, H, B>
+where
+    L: LessonsSource,
+    H: HdcReplaySource,
+    B: KgBackend,
+{
+    pub fn new(lessons: L, hdc: H, adapter: KgAdapter<B>) -> Self;
+
+    /// Forward direction. Drains both sources concurrently into the KG.
+    /// Returns once both source streams complete or `cancel.notified()` fires.
+    pub async fn run(&self, cancel: tokio::sync::Notify) -> BridgeStats;
+
+    /// Reverse direction. Pulls KG triples within `lookback` back into the
+    /// supplied seed sink (e.g. an HDC replay buffer's warm-start path).
+    pub async fn seed_replay<S: HdcSeedSink>(
+        &self,
+        sink: &mut S,
+        lookback: Duration,
+    ) -> Result<usize, BridgeErr>;
+}
+
+pub trait LessonsSource: Send + Sync { /* stream() -> LessonRow */ }
+pub trait HdcReplaySource: Send + Sync { /* stream() -> HdcEpisode */ }
+pub trait HdcSeedSink: Send + Sync { /* seed(&Triple) -> Result */ }
+
+pub struct LessonRow { kind, subject, predicate, object, ts }
+pub struct HdcEpisode { hyper_id, subject, predicate, object, ts }
+pub struct BridgeStats { lessons_forwarded, hdc_forwarded, errors }
+pub enum  BridgeErr { Source(String), Adapter(AdapterErr), Cancelled }
+```
+
+## Tests
+
+| Group | Tests |
+|---|---|
+| Forward | `forward_lessons_into_kg`, `forward_hdc_into_kg`, `forward_concurrent_both_sources` |
+| Reverse | `seed_replay_pulls_recent_triples`, `seed_replay_respects_lookback`, `seed_replay_handles_empty_kg` |
+| Cancellation | `run_honors_cancel_notify` |
+| Errors | `forward_continues_after_source_error`, `seed_replay_propagates_kg_error` |
+| Read-only | `lessons_source_is_immutable_view` (compile-time: trait has no `&mut self`) |
+| φ-anchor | `phi_anchor_present` |
+
+All tests use in-memory mocks (`MockLessons`, `MockHdc`, `MockKg`).
+
+## Dependencies (R-RING-DEP-002)
+
+```
+serde, serde_json, chrono, thiserror, tracing, tokio
++ trios-agent-memory-sr-mem-00 (Triple, TripleId, Provenance, AgentRole)
++ trios-agent-memory-sr-mem-01 (KgAdapter, KgBackend, RecallPattern)
+```
+
+No `sqlx`, no `reqwest`, no Zig FFI. Those land in the sibling BR-IO ring.
+
+## Smoke-test deferral (R5)
+
+The issue AC closes with `Smoke test against Neon dev DB`. The sandbox has
+no `NEON_DATABASE_URL` and the concrete listener/FFI adapters live in
+BR-IO. The smoke test ships with the BR-IO adapter PR + a `NEON_TEST_URL`
+CI secret. This ring's contract tests are the layer that's verifiable
+right now.
+
+🌻 `α_φ = φ⁻³ / 2 ≈ 0.1180` · `phi^2 + phi^-2 = 3`

--- a/crates/trios-agent-memory/rings/SR-MEM-05/RING.md
+++ b/crates/trios-agent-memory/rings/SR-MEM-05/RING.md
@@ -1,0 +1,34 @@
+# RING — SR-MEM-05
+
+| Field | Value |
+|---|---|
+| Tier | 🥈 Silver |
+| Crate | `trios-agent-memory-sr-mem-05` |
+| Path | `crates/trios-agent-memory/rings/SR-MEM-05/` |
+| Deps in | `trios-agent-memory-sr-mem-00`, `trios-agent-memory-sr-mem-01`, `serde`, `serde_json`, `chrono`, `thiserror`, `tracing`, `tokio` (runtime primitives only) |
+| Deps out (path) | none yet — wired into BR-OUTPUT after this PR merges |
+| I/O | none (Silver-tier; concrete sqlx + Zig-FFI adapters live in sibling BR-IO ring) |
+| Public verbs | `Bridge::run`, `Bridge::seed_replay` |
+| Public traits | `LessonsSource`, `HdcReplaySource`, `HdcSeedSink` |
+| Public types | `LessonRow`, `HdcEpisode`, `BridgeStats`, `BridgeErr` |
+
+## Ring contract
+
+- **In:** events from `LessonsSource` (Neon NOTIFY-style) and
+  `HdcReplaySource` (Zig-FFI replay buffer).
+- **Process:** translate each event into a `Triple` with full
+  `Provenance`, then call `KgAdapter::remember_triple` (SR-MEM-01).
+- **Out (forward):** triples persisted into KG; `BridgeStats` returned
+  on shutdown.
+- **Out (reverse):** `seed_replay` pulls KG triples within `lookback`
+  back into a `HdcSeedSink` for warm-start of the HDC replay buffer.
+
+## Sibling BR-IO ring
+
+The concrete `sqlx::PgListener` (Neon NOTIFY) and Zig-FFI shim against
+`streaming_memory.zig` live in
+`crates/trios-agent-memory/rings/BR-IO-MEM-05/` (future PR). They
+implement `LessonsSource` and `HdcReplaySource` against the live data
+plane.
+
+🌻 `phi^2 + phi^-2 = 3`

--- a/crates/trios-agent-memory/rings/SR-MEM-05/TASK.md
+++ b/crates/trios-agent-memory/rings/SR-MEM-05/TASK.md
@@ -1,0 +1,32 @@
+# SR-MEM-05 — TASK
+
+**Closes:** #455 · **Part of:** #446 · **Soul:** Loop-Locksmith · **Tier:** 🥈 Silver
+
+## Goal
+
+Bidirectional bridge between the two existing episodic stores (Neon `lessons`
+table + HDC replay buffer) and the KG long-term memory exposed via
+SR-MEM-01.
+
+## Acceptance criteria (issue AC ↔ this ring)
+
+- [x] `rings/SR-MEM-05/` with I5 trinity (README, TASK, AGENTS, RING, Cargo, lib).
+- [x] Deps: SR-MEM-00, SR-MEM-01, `tokio` runtime primitives, `tracing`, `thiserror`.
+- [x] Forward direction: `Bridge::run` drains `LessonsSource` + `HdcReplaySource`
+      into the KG via `KgAdapter::remember_triple`.
+- [x] Reverse direction: `Bridge::seed_replay(&mut HdcSeedSink, lookback)` pulls
+      KG triples back into the supplied warm-start sink.
+- [x] Read-only forwarder on `lessons.rs` (L21 immutability) — `LessonsSource`
+      trait has no `&mut` write surface.
+- [ ] Smoke against Neon dev DB — **deferred to BR-IO adapter PR**
+      (sibling ring; needs `NEON_TEST_URL` CI secret).
+- [x] PR closes this issue, `Agent: Loop-Locksmith` trailer.
+
+## Honest scope (R5)
+
+Concrete `sqlx::PgListener` and Zig-FFI HDC reader live in a sibling BR-IO
+ring (same precedent as `trios_kg::KgClient` for SR-MEM-01). This ring
+ships the contract + state machine + reverse `seed_replay`, all tested
+against in-memory mocks.
+
+🌻 `phi^2 + phi^-2 = 3`

--- a/crates/trios-agent-memory/rings/SR-MEM-05/src/lib.rs
+++ b/crates/trios-agent-memory/rings/SR-MEM-05/src/lib.rs
@@ -1,0 +1,838 @@
+//! SR-MEM-05 — Episodic Bridge (lessons.rs + HDC ↔ KG).
+//!
+//! Bidirectional bridge between the two existing episodic stores and
+//! the KG long-term memory exposed via SR-MEM-01:
+//!
+//! - **Forward (lessons → KG):** any [`LessonsSource`] yields rows that
+//!   were already written into the Neon `lessons` table by
+//!   `crates/trios-igla-race/src/lessons.rs`. Each row is translated
+//!   into a [`Triple`] and persisted via [`KgAdapter::remember_triple`].
+//!
+//! - **Forward (HDC → KG):** any [`HdcReplaySource`] yields hyper-vector
+//!   episodes from the HDC replay buffer
+//!   (`crates/trios-sacred/src/phi-engine/hdc/rl_agent_memory.zig`).
+//!   Each episode is translated into a [`Triple`] and persisted.
+//!
+//! - **Reverse (KG → HDC seed):** [`Bridge::seed_replay`] pulls the most
+//!   recent KG triples for warm-starting the HDC replay buffer.
+//!
+//! ## Honest scope (R5)
+//!
+//! This ring ships the **contract + state machine**. The concrete
+//! `sqlx::PgListener` (Neon NOTIFY listener) and Zig-FFI shim against
+//! `streaming_memory.zig` ship in a sibling BR-IO ring (same precedent
+//! as `trios_kg::KgClient` for SR-MEM-01). Pulling sqlx + Zig FFI into
+//! a Silver ring would violate `R-RING-DEP-002` and the issue itself
+//! marks the FFI binding as "TODO if Zig FFI not yet ready".
+//!
+//! Smoke against Neon dev DB requires `NEON_TEST_URL`; that smoke runs
+//! in the BR-IO adapter PR, not here.
+//!
+//! Closes #455 · Part of #446 · Anchor: phi^2 + phi^-2 = 3
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::Notify;
+use tracing::{debug, instrument, warn};
+
+use trios_agent_memory_sr_mem_00::{AgentRole, Provenance, Triple, TripleId};
+use trios_agent_memory_sr_mem_01::{AdapterErr, KgAdapter, KgBackend, RecallPattern};
+
+// ───────────── source row types ─────────────
+
+/// One row materialised from the Neon `lessons` table by a
+/// [`LessonsSource`]. The forwarder turns each row into a triple
+/// `(subject="lesson:<kind>", predicate=predicate, object=object)` with
+/// `Provenance.agent_id = AgentRole::Lead` (lessons are governance
+/// artefacts).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LessonRow {
+    /// `AVOID` / `PATTERN` / `WINNER` / `WARN` / `INFO` from
+    /// `lessons.rs::LessonType`.
+    pub kind: String,
+    /// Triple subject (e.g. `"trial:abc123"`).
+    pub subject: String,
+    /// Triple predicate (e.g. `"failed_with"`).
+    pub predicate: String,
+    /// Triple object (e.g. `"loss=NaN"`).
+    pub object: String,
+    /// Row timestamp (UTC).
+    pub ts: DateTime<Utc>,
+    /// Source SHA: git commit or trial id (32-byte hex; pad with zeros
+    /// if not available).
+    pub source_sha_hex: String,
+}
+
+/// One episode read from the HDC replay buffer by an
+/// [`HdcReplaySource`]. The forwarder turns each episode into a triple
+/// with `Provenance.agent_id = AgentRole::Scarab`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HdcEpisode {
+    /// Hyper-id of the episode (HDC content address).
+    pub hyper_id: String,
+    /// Triple subject (e.g. `"episode:42"`).
+    pub subject: String,
+    /// Triple predicate (e.g. `"observed"`).
+    pub predicate: String,
+    /// Triple object (free-form).
+    pub object: String,
+    /// Episode timestamp (UTC).
+    pub ts: DateTime<Utc>,
+}
+
+// ───────────── source traits ─────────────
+
+/// Stream of [`LessonRow`] events. Implementations:
+///
+/// - `MockLessons` (this file's tests).
+/// - Concrete `sqlx::PgListener` adapter in the sibling BR-IO ring
+///   (subscribes to `LISTEN lessons_channel` on the Neon `lessons`
+///   table).
+///
+/// The trait deliberately has no `&mut self` method: SR-MEM-05 is a
+/// **read-only forwarder** (L21 context immutability — we never write
+/// back into `lessons.rs`).
+pub trait LessonsSource: Send + Sync {
+    /// Pop the next row (or `None` if the source has drained / closed).
+    /// Implementations should make this cancel-safe (i.e. cancellable
+    /// via outer `tokio::select!`).
+    fn next_row<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<LessonRow>, String>> + Send + 'a>>;
+}
+
+/// Stream of [`HdcEpisode`] events. Implementations:
+///
+/// - `MockHdc` (this file's tests).
+/// - Concrete Zig-FFI adapter against `streaming_memory.zig` exports
+///   in the sibling BR-IO ring.
+pub trait HdcReplaySource: Send + Sync {
+    /// Pop the next episode (or `None` if the buffer drained).
+    fn next_episode<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<HdcEpisode>, String>> + Send + 'a>>;
+}
+
+/// Sink that the reverse direction ([`Bridge::seed_replay`]) writes
+/// recent KG triples into. The HDC replay buffer's warm-start path is
+/// the canonical implementor.
+pub trait HdcSeedSink: Send {
+    /// Seed one triple. `Err` aborts the seed_replay run.
+    fn seed<'a>(
+        &'a mut self,
+        triple: &'a Triple,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
+}
+
+// ───────────── bridge stats / errors ─────────────
+
+/// Cumulative forward-direction stats. Returned from [`Bridge::run`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BridgeStats {
+    /// Lessons rows forwarded into KG.
+    pub lessons_forwarded: usize,
+    /// HDC episodes forwarded into KG.
+    pub hdc_forwarded: usize,
+    /// Total source-side or adapter-side errors observed (bridge keeps
+    /// running on error — only the offending event is dropped).
+    pub errors: usize,
+}
+
+/// Bridge errors.
+#[derive(Debug, Error)]
+pub enum BridgeErr {
+    /// Source returned a hard error (passed through).
+    #[error("source error: {0}")]
+    Source(String),
+    /// KG adapter returned an error.
+    #[error("adapter error: {0}")]
+    Adapter(#[from] AdapterErr),
+    /// Cancellation was requested via the cancel `Notify`.
+    #[error("cancelled")]
+    Cancelled,
+}
+
+// ───────────── translation helpers ─────────────
+
+/// Build a deterministic 32-byte source SHA from a hex string. If the
+/// input is shorter than 64 hex chars, it is right-padded with zeros;
+/// non-hex bytes are mapped via SHA hashing.
+fn parse_source_sha(hex: &str) -> TripleId {
+    // Use TripleId::from_triple for deterministic hashing of arbitrary
+    // string identifiers (avoids depending on `hex` crate at Silver).
+    TripleId::from_triple("source_sha", hex, "")
+}
+
+fn lesson_to_triple(row: &LessonRow, task_id: uuid::Uuid) -> Triple {
+    let prov = Provenance {
+        agent_id: AgentRole::Lead,
+        task_id,
+        source_sha: parse_source_sha(&row.source_sha_hex),
+        ts: row.ts,
+    };
+    // Encode lesson kind into the subject so downstream pattern recall
+    // can filter by `subject = "lesson:<kind>:<subject>"`.
+    let composite_subject = format!("lesson:{}:{}", row.kind.to_lowercase(), row.subject);
+    Triple::new(
+        composite_subject,
+        row.predicate.clone(),
+        row.object.clone(),
+        prov,
+    )
+}
+
+fn episode_to_triple(ep: &HdcEpisode, task_id: uuid::Uuid) -> Triple {
+    let prov = Provenance {
+        agent_id: AgentRole::Scarab,
+        task_id,
+        source_sha: parse_source_sha(&ep.hyper_id),
+        ts: ep.ts,
+    };
+    let composite_subject = format!("hdc:{}", ep.subject);
+    Triple::new(composite_subject, ep.predicate.clone(), ep.object.clone(), prov)
+}
+
+// ───────────── Bridge ─────────────
+
+/// Bidirectional bridge between (Lessons + HDC) and the KG.
+pub struct Bridge<L: LessonsSource, H: HdcReplaySource, B: KgBackend> {
+    lessons: Arc<L>,
+    hdc: Arc<H>,
+    adapter: Arc<KgAdapter<B>>,
+    /// One stable task_id that tags every triple this bridge minted in
+    /// its lifetime. Lets downstream readers correlate forwards.
+    task_id: uuid::Uuid,
+    /// Forward stats counters (atomic so concurrent forward loops can
+    /// share state cheaply).
+    lessons_count: AtomicUsize,
+    hdc_count: AtomicUsize,
+    err_count: AtomicUsize,
+}
+
+impl<L: LessonsSource, H: HdcReplaySource, B: KgBackend> Bridge<L, H, B> {
+    /// Build a new bridge. The bridge's `task_id` is generated once
+    /// here and tags every triple it forwards.
+    pub fn new(lessons: L, hdc: H, adapter: KgAdapter<B>) -> Self {
+        Self {
+            lessons: Arc::new(lessons),
+            hdc: Arc::new(hdc),
+            adapter: Arc::new(adapter),
+            task_id: uuid::Uuid::new_v4(),
+            lessons_count: AtomicUsize::new(0),
+            hdc_count: AtomicUsize::new(0),
+            err_count: AtomicUsize::new(0),
+        }
+    }
+
+    /// Test/diagnostic helper: stable task_id this bridge is tagging
+    /// triples with.
+    pub fn task_id(&self) -> uuid::Uuid {
+        self.task_id
+    }
+
+    /// Snapshot the current forward stats without stopping the bridge.
+    pub fn stats(&self) -> BridgeStats {
+        BridgeStats {
+            lessons_forwarded: self.lessons_count.load(Ordering::Relaxed),
+            hdc_forwarded: self.hdc_count.load(Ordering::Relaxed),
+            errors: self.err_count.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Forward direction. Drains both sources concurrently into the KG.
+    /// Returns once both source streams complete OR `cancel.notified()`
+    /// fires. Errors on a single event do not stop the bridge — they
+    /// are counted in [`BridgeStats::errors`] and the offending event
+    /// is dropped.
+    #[instrument(skip(self, cancel))]
+    pub async fn run(&self, cancel: Arc<Notify>) -> BridgeStats {
+        let lessons = Arc::clone(&self.lessons);
+        let hdc = Arc::clone(&self.hdc);
+        let adapter = Arc::clone(&self.adapter);
+        let task_id = self.task_id;
+
+        // We can't share AtomicUsize references across two spawned
+        // tasks without &'static, but we own self for the duration of
+        // run(), so we use scoped concurrency via tokio::join! over two
+        // local async blocks instead of tokio::spawn.
+        let lessons_loop = async {
+            let mut local_ok = 0usize;
+            let mut local_err = 0usize;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel.notified() => break,
+                    row = lessons.next_row() => match row {
+                        Ok(Some(r)) => {
+                            let triple = lesson_to_triple(&r, task_id);
+                            match adapter.remember_triple(&triple).await {
+                                Ok(_) => { local_ok += 1; }
+                                Err(e) => {
+                                    warn!(error = %e, "lessons forward failed");
+                                    local_err += 1;
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            debug!("lessons source drained");
+                            break;
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "lessons source error");
+                            local_err += 1;
+                        }
+                    }
+                }
+            }
+            (local_ok, local_err)
+        };
+
+        let hdc_loop = async {
+            let mut local_ok = 0usize;
+            let mut local_err = 0usize;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel.notified() => break,
+                    ep = hdc.next_episode() => match ep {
+                        Ok(Some(e)) => {
+                            let triple = episode_to_triple(&e, task_id);
+                            match adapter.remember_triple(&triple).await {
+                                Ok(_) => { local_ok += 1; }
+                                Err(err) => {
+                                    warn!(error = %err, "hdc forward failed");
+                                    local_err += 1;
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            debug!("hdc source drained");
+                            break;
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "hdc source error");
+                            local_err += 1;
+                        }
+                    }
+                }
+            }
+            (local_ok, local_err)
+        };
+
+        let ((l_ok, l_err), (h_ok, h_err)) = tokio::join!(lessons_loop, hdc_loop);
+        self.lessons_count.fetch_add(l_ok, Ordering::Relaxed);
+        self.hdc_count.fetch_add(h_ok, Ordering::Relaxed);
+        self.err_count.fetch_add(l_err + h_err, Ordering::Relaxed);
+        self.stats()
+    }
+
+    /// Reverse direction. Pulls KG triples back into the supplied seed
+    /// sink. `lookback` is currently advisory: this ring filters
+    /// post-recall by `triple.provenance.ts`. Returns the count of
+    /// triples seeded.
+    ///
+    /// Recall is keyed off the triples this bridge minted (subjects
+    /// prefixed with `"lesson:"` or `"hdc:"`); a downstream caller
+    /// needing a wider seed window should call `KgAdapter::recall_by_pattern`
+    /// directly with the pattern of their choice.
+    #[instrument(skip(self, sink))]
+    pub async fn seed_replay<S: HdcSeedSink>(
+        &self,
+        sink: &mut S,
+        lookback: Duration,
+    ) -> Result<usize, BridgeErr> {
+        let now = Utc::now();
+        let cutoff = now
+            - chrono::Duration::from_std(lookback).unwrap_or_else(|_| chrono::Duration::seconds(0));
+
+        // Pull lesson- and hdc-prefixed triples in two recalls; we do
+        // not have a direct "ts >=" query in SR-MEM-01 (RecallPattern
+        // is SPO-only), so we filter in-memory by provenance.ts. Budget
+        // is generous (10_000) — the gardener writes O(few) per tick.
+        let lesson_pattern = RecallPattern::default();
+        let candidates = self
+            .adapter
+            .recall_by_pattern(&lesson_pattern, 10_000)
+            .await?;
+        let mut seeded = 0usize;
+        for triple in candidates.iter() {
+            let is_ours = triple.subject.starts_with("lesson:")
+                || triple.subject.starts_with("hdc:");
+            if !is_ours {
+                continue;
+            }
+            if triple.provenance.ts < cutoff {
+                continue;
+            }
+            sink.seed(triple)
+                .await
+                .map_err(BridgeErr::Source)?;
+            seeded += 1;
+        }
+        Ok(seeded)
+    }
+}
+
+// ───────────── tests ─────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+    use trios_agent_memory_sr_mem_01::KgBackend as KgBackendTrait;
+
+    fn ts_now() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    fn lesson_row(kind: &str, subj: &str, pred: &str, obj: &str) -> LessonRow {
+        LessonRow {
+            kind: kind.into(),
+            subject: subj.into(),
+            predicate: pred.into(),
+            object: obj.into(),
+            ts: ts_now(),
+            source_sha_hex: "deadbeef".into(),
+        }
+    }
+
+    fn hdc_episode(hyper: &str, subj: &str, pred: &str, obj: &str) -> HdcEpisode {
+        HdcEpisode {
+            hyper_id: hyper.into(),
+            subject: subj.into(),
+            predicate: pred.into(),
+            object: obj.into(),
+            ts: ts_now(),
+        }
+    }
+
+    // ── mock lessons source ──
+
+    struct MockLessons {
+        rows: StdMutex<Vec<LessonRow>>,
+        // If > 0, the next call to `next_row` returns Err.
+        fail_next: StdMutex<u32>,
+    }
+
+    impl MockLessons {
+        fn new(rows: Vec<LessonRow>) -> Self {
+            Self {
+                rows: StdMutex::new(rows.into_iter().rev().collect()),
+                fail_next: StdMutex::new(0),
+            }
+        }
+        fn fail_for(&self, n: u32) {
+            *self.fail_next.lock().unwrap() = n;
+        }
+    }
+
+    impl LessonsSource for MockLessons {
+        fn next_row<'a>(
+            &'a self,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<LessonRow>, String>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                {
+                    let mut n = self.fail_next.lock().unwrap();
+                    if *n > 0 {
+                        *n -= 1;
+                        return Err("mock lessons error".into());
+                    }
+                }
+                Ok(self.rows.lock().unwrap().pop())
+            })
+        }
+    }
+
+    // ── mock hdc source ──
+
+    struct MockHdc {
+        eps: StdMutex<Vec<HdcEpisode>>,
+    }
+
+    impl MockHdc {
+        fn new(eps: Vec<HdcEpisode>) -> Self {
+            Self {
+                eps: StdMutex::new(eps.into_iter().rev().collect()),
+            }
+        }
+    }
+
+    impl HdcReplaySource for MockHdc {
+        fn next_episode<'a>(
+            &'a self,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<HdcEpisode>, String>> + Send + 'a>>
+        {
+            Box::pin(async move { Ok(self.eps.lock().unwrap().pop()) })
+        }
+    }
+
+    // ── mock KG backend ──
+
+    struct MockKg {
+        store: StdMutex<HashMap<TripleId, Triple>>,
+    }
+
+    impl MockKg {
+        fn new() -> Self {
+            Self {
+                store: StdMutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl KgBackendTrait for MockKg {
+        fn put_triple<'a>(
+            &'a self,
+            triple: &'a Triple,
+        ) -> Pin<Box<dyn Future<Output = Result<TripleId, String>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                self.store.lock().unwrap().insert(triple.id, triple.clone());
+                Ok(triple.id)
+            })
+        }
+        fn query_pattern<'a>(
+            &'a self,
+            pattern: &'a RecallPattern,
+            budget: usize,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<Triple>, String>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                let mut out: Vec<Triple> = self
+                    .store
+                    .lock()
+                    .unwrap()
+                    .values()
+                    .filter(|t| pattern.matches(t))
+                    .cloned()
+                    .collect();
+                out.truncate(budget);
+                Ok(out)
+            })
+        }
+        fn delete_triple<'a>(
+            &'a self,
+            id: TripleId,
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                self.store.lock().unwrap().remove(&id);
+                Ok(())
+            })
+        }
+    }
+
+    // ── seed sink ──
+
+    struct VecSeedSink(Vec<Triple>);
+
+    impl HdcSeedSink for VecSeedSink {
+        fn seed<'a>(
+            &'a mut self,
+            triple: &'a Triple,
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                self.0.push(triple.clone());
+                Ok(())
+            })
+        }
+    }
+
+    fn build_bridge(
+        lessons: Vec<LessonRow>,
+        eps: Vec<HdcEpisode>,
+    ) -> (
+        Bridge<MockLessons, MockHdc, MockKg>,
+        Arc<KgAdapter<MockKg>>,
+    ) {
+        // Build KgAdapter inline so tests can also recall through it.
+        let adapter = KgAdapter::new(MockKg::new());
+        // Re-clone the adapter for direct test access by wrapping again.
+        let bridge = Bridge::new(MockLessons::new(lessons), MockHdc::new(eps), adapter);
+        // The bridge owns the adapter; for tests that need a separate
+        // handle, build a parallel adapter on a fresh backend. To keep
+        // things simple, return the bridge alone (tests below use
+        // `bridge.adapter` indirectly through seed_replay).
+        let bridge_adapter = Arc::clone(&bridge.adapter);
+        (bridge, bridge_adapter)
+    }
+
+    // ── tests ──
+
+    #[tokio::test]
+    async fn forward_lessons_into_kg() {
+        let (bridge, adapter) = build_bridge(
+            vec![
+                lesson_row("AVOID", "trial:abc", "failed_with", "loss=NaN"),
+                lesson_row("WINNER", "trial:xyz", "achieved", "bpb=2.19"),
+            ],
+            vec![],
+        );
+        let cancel = Arc::new(Notify::new());
+        let stats = bridge.run(cancel).await;
+        assert_eq!(stats.lessons_forwarded, 2);
+        assert_eq!(stats.hdc_forwarded, 0);
+        assert_eq!(stats.errors, 0);
+        let hits = adapter
+            .recall_by_pattern(&RecallPattern::default(), 100)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 2);
+        // Subject is composite-prefixed.
+        assert!(hits.iter().all(|t| t.subject.starts_with("lesson:")));
+    }
+
+    #[tokio::test]
+    async fn forward_hdc_into_kg() {
+        let (bridge, adapter) = build_bridge(
+            vec![],
+            vec![
+                hdc_episode("h:001", "ep:1", "observed", "phi"),
+                hdc_episode("h:002", "ep:2", "observed", "psi"),
+            ],
+        );
+        let cancel = Arc::new(Notify::new());
+        let stats = bridge.run(cancel).await;
+        assert_eq!(stats.lessons_forwarded, 0);
+        assert_eq!(stats.hdc_forwarded, 2);
+        assert_eq!(stats.errors, 0);
+        let hits = adapter
+            .recall_by_pattern(&RecallPattern::default(), 100)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().all(|t| t.subject.starts_with("hdc:")));
+    }
+
+    #[tokio::test]
+    async fn forward_concurrent_both_sources() {
+        let (bridge, adapter) = build_bridge(
+            vec![
+                lesson_row("AVOID", "t:1", "failed", "x"),
+                lesson_row("WINNER", "t:2", "won", "y"),
+                lesson_row("INFO", "t:3", "noted", "z"),
+            ],
+            vec![
+                hdc_episode("h:1", "e1", "p", "o"),
+                hdc_episode("h:2", "e2", "p", "o"),
+            ],
+        );
+        let cancel = Arc::new(Notify::new());
+        let stats = bridge.run(cancel).await;
+        assert_eq!(stats.lessons_forwarded, 3);
+        assert_eq!(stats.hdc_forwarded, 2);
+        assert_eq!(stats.errors, 0);
+        let total = adapter
+            .recall_by_pattern(&RecallPattern::default(), 100)
+            .await
+            .unwrap();
+        assert_eq!(total.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn forward_continues_after_source_error() {
+        // Inject 2 errors into the lessons stream; the rows after the
+        // errors must still flow through.
+        let lessons = MockLessons::new(vec![
+            lesson_row("AVOID", "t:1", "f", "x"),
+            lesson_row("WINNER", "t:2", "w", "y"),
+        ]);
+        lessons.fail_for(2);
+        let bridge = Bridge::new(lessons, MockHdc::new(vec![]), KgAdapter::new(MockKg::new()));
+        let cancel = Arc::new(Notify::new());
+        let stats = bridge.run(cancel).await;
+        // 2 rows still made it through after the 2 injected errors.
+        assert_eq!(stats.lessons_forwarded, 2);
+        assert_eq!(stats.errors, 2);
+    }
+
+    #[tokio::test]
+    async fn run_honors_cancel_notify() {
+        // A "never-drains" lessons source so the bridge would loop
+        // forever without cancellation.
+        struct NeverDrains;
+        impl LessonsSource for NeverDrains {
+            fn next_row<'a>(
+                &'a self,
+            ) -> Pin<
+                Box<dyn Future<Output = Result<Option<LessonRow>, String>> + Send + 'a>,
+            > {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    Ok(None)
+                })
+            }
+        }
+        let bridge = Bridge::new(NeverDrains, MockHdc::new(vec![]), KgAdapter::new(MockKg::new()));
+        let cancel = Arc::new(Notify::new());
+        let cancel_clone = Arc::clone(&cancel);
+        let handle = tokio::spawn(async move { bridge.run(cancel_clone).await });
+        // Give the loop a moment to enter `select!`.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel.notify_waiters();
+        // The notify wakes both legs (lessons + hdc); MockHdc with []
+        // drains immediately, lessons leg respects cancel.
+        let stats = tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("run did not return after cancel")
+            .expect("join error");
+        assert_eq!(stats.lessons_forwarded, 0);
+    }
+
+    #[tokio::test]
+    async fn seed_replay_pulls_recent_triples() {
+        let (bridge, _) = build_bridge(
+            vec![lesson_row("WINNER", "t:1", "won", "y")],
+            vec![hdc_episode("h:1", "e1", "p", "o")],
+        );
+        let cancel = Arc::new(Notify::new());
+        let _ = bridge.run(cancel).await;
+        let mut sink = VecSeedSink(Vec::new());
+        let n = bridge
+            .seed_replay(&mut sink, Duration::from_secs(60 * 60))
+            .await
+            .unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(sink.0.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn seed_replay_respects_lookback() {
+        let (bridge, _) = build_bridge(
+            vec![lesson_row("INFO", "t:1", "noted", "z")],
+            vec![],
+        );
+        let cancel = Arc::new(Notify::new());
+        let _ = bridge.run(cancel).await;
+        // 0-second lookback excludes everything (since `cutoff = now`).
+        // Use `Duration::from_nanos(1)` for a strictly-positive lookback;
+        // any triple minted before "now - 1ns" is excluded.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let mut sink = VecSeedSink(Vec::new());
+        let n = bridge
+            .seed_replay(&mut sink, Duration::from_nanos(1))
+            .await
+            .unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn seed_replay_handles_empty_kg() {
+        let (bridge, _) = build_bridge(vec![], vec![]);
+        let mut sink = VecSeedSink(Vec::new());
+        let n = bridge
+            .seed_replay(&mut sink, Duration::from_secs(3600))
+            .await
+            .unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn seed_replay_propagates_sink_error() {
+        struct BadSink;
+        impl HdcSeedSink for BadSink {
+            fn seed<'a>(
+                &'a mut self,
+                _triple: &'a Triple,
+            ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>
+            {
+                Box::pin(async move { Err("sink full".into()) })
+            }
+        }
+        let (bridge, _) = build_bridge(
+            vec![lesson_row("WARN", "t:1", "noted", "x")],
+            vec![],
+        );
+        let cancel = Arc::new(Notify::new());
+        let _ = bridge.run(cancel).await;
+        let mut sink = BadSink;
+        match bridge
+            .seed_replay(&mut sink, Duration::from_secs(3600))
+            .await
+        {
+            Err(BridgeErr::Source(msg)) => assert_eq!(msg, "sink full"),
+            other => panic!("expected Source(sink full), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn seed_replay_skips_foreign_triples() {
+        // A bridge that only forwarded lessons; manually inject a
+        // foreign-prefix triple into the same KG via the adapter, then
+        // confirm seed_replay skips it.
+        let (bridge, adapter) = build_bridge(
+            vec![lesson_row("AVOID", "t:1", "failed", "x")],
+            vec![],
+        );
+        let cancel = Arc::new(Notify::new());
+        let _ = bridge.run(cancel).await;
+        // Foreign triple (subject doesn't start with lesson:/hdc:).
+        let prov = Provenance {
+            agent_id: AgentRole::Doctor,
+            task_id: uuid::Uuid::new_v4(),
+            source_sha: TripleId::from_triple("foreign", "x", ""),
+            ts: Utc::now(),
+        };
+        adapter
+            .remember_triple(&Triple::new("doctor:rule", "asserts", "L1", prov))
+            .await
+            .unwrap();
+        let mut sink = VecSeedSink(Vec::new());
+        let n = bridge
+            .seed_replay(&mut sink, Duration::from_secs(3600))
+            .await
+            .unwrap();
+        // Only the lesson was seeded; doctor:rule was skipped.
+        assert_eq!(n, 1);
+        assert!(sink.0[0].subject.starts_with("lesson:"));
+    }
+
+    #[test]
+    fn lessons_source_is_immutable_view() {
+        // Compile-time guarantee: `LessonsSource::next_row` takes
+        // `&self`, so a downstream impl cannot expose a mutable write
+        // path through this trait. (L21 context immutability.)
+        fn assert_send_sync<T: Send + Sync + ?Sized>() {}
+        assert_send_sync::<dyn LessonsSource>();
+    }
+
+    #[test]
+    fn phi_anchor_present() {
+        let phi: f64 = (1.0 + 5.0_f64.sqrt()) / 2.0;
+        let lhs = phi * phi + 1.0 / (phi * phi);
+        assert!((lhs - 3.0).abs() < 1e-10, "phi anchor violated: {lhs}");
+    }
+
+    #[test]
+    fn translation_uses_lead_role_for_lessons() {
+        let row = lesson_row("AVOID", "t:1", "failed_with", "loss=NaN");
+        let task_id = uuid::Uuid::nil();
+        let triple = lesson_to_triple(&row, task_id);
+        assert_eq!(triple.provenance.agent_id, AgentRole::Lead);
+        assert_eq!(triple.subject, "lesson:avoid:t:1");
+        assert_eq!(triple.predicate, "failed_with");
+        assert_eq!(triple.object, "loss=NaN");
+    }
+
+    #[test]
+    fn translation_uses_scarab_role_for_hdc() {
+        let ep = hdc_episode("h:1", "ep:1", "observed", "phi");
+        let task_id = uuid::Uuid::nil();
+        let triple = episode_to_triple(&ep, task_id);
+        assert_eq!(triple.provenance.agent_id, AgentRole::Scarab);
+        assert_eq!(triple.subject, "hdc:ep:1");
+    }
+}


### PR DESCRIPTION
Closes #455 · Part of #446 · Anchor: \`phi² + phi⁻² = 3\`

## What

Silver-tier bidirectional bridge between the two existing episodic stores and the KG long-term memory exposed via SR-MEM-01:

- **Forward (lessons → KG)** via \`LessonsSource\` trait
- **Forward (HDC → KG)** via \`HdcReplaySource\` trait
- **Reverse (KG → HDC seed)** via \`Bridge::seed_replay\` over any \`HdcSeedSink\`
- Concurrent forward loops with \`tokio::join!\`, cancellation via \`Notify\`
- Per-event errors are counted (\`BridgeStats::errors\`) but do not stop the bridge

## Acceptance criteria (issue ↔ this PR)

| Issue AC | Where it lives |
|---|---|
| \`rings/SR-MEM-05/\` with I5 trinity | README/TASK/AGENTS/RING/Cargo/lib all present |
| Deps: SR-MEM-00, SR-MEM-01, tokio | ✅ + tracing/thiserror/serde/uuid/chrono |
| \`Bridge::start\` subscribes to NOTIFY → forwards as triple | \`Bridge::run\` over \`LessonsSource::next_row\` → \`KgAdapter::remember_triple\` |
| HDC forwarder reads streaming_memory.zig | \`Bridge::run\` over \`HdcReplaySource::next_episode\` |
| Reverse: \`seed_replay(&mut HdcMemory, lookback)\` | \`Bridge::seed_replay<S: HdcSeedSink>(sink, lookback)\` |
| Read-only on lessons.rs (L21) | \`LessonsSource\` trait has no \`&mut self\` — compile-time guarantee, asserted by \`lessons_source_is_immutable_view\` test |
| Smoke against Neon dev DB | **Deferred to sibling BR-IO PR** (needs NEON_TEST_URL secret); R5-honest disclosure in README §Honest scope |
| PR closes this issue, \`Agent: <SoulName>\` trailer | ✅ \`Agent: Loop-Locksmith\` |

## Tests (14/14 GREEN, 0 clippy warnings)

| Group | Tests |
|---|---|
| Forward | forward_lessons_into_kg, forward_hdc_into_kg, forward_concurrent_both_sources |
| Reverse | seed_replay_pulls_recent_triples, seed_replay_respects_lookback, seed_replay_handles_empty_kg, seed_replay_skips_foreign_triples |
| Cancellation | run_honors_cancel_notify |
| Errors | forward_continues_after_source_error, seed_replay_propagates_sink_error |
| Read-only contract | lessons_source_is_immutable_view |
| Translation | translation_uses_lead_role_for_lessons, translation_uses_scarab_role_for_hdc |
| φ-anchor | phi_anchor_present |

## R5 honest disclosure

- The concrete \`sqlx::PgListener\` (Neon NOTIFY listener) and Zig-FFI shim against \`streaming_memory.zig\` live in a sibling BR-IO ring (same precedent as \`trios_kg::KgClient\` for SR-MEM-01). Pulling sqlx + Zig FFI into a Silver ring would violate R-RING-DEP-002 and the issue itself flags Zig FFI as TODO.
- \`Bridge::seed_replay\` filters in-memory by \`provenance.ts\` because \`SR-MEM-01::RecallPattern\` is SPO-only (no native ts query); fine for current call volumes (gardener writes O(few) per tick).
- The smoke-test AC is honestly deferred to the BR-IO adapter PR; this ring's contract tests are the layer that's verifiable right now.

## Constitutional rules

R1 · R5-honest · R-RING-DEP-002 · R-L6-PURE-007 · L1 · L13 (I-SCOPE) · L14 · I5 · L21 (read-only forwarder)

Soul: \`Loop-Locksmith\` · Three-roads: \`.trinity/state/three-roads-455.json\` (chose road_b: trait-contract ring)

🌻 \`α_φ = φ⁻³ / 2 ≈ 0.1180\`

Agent: Loop-Locksmith