### PR TITLE
chore(phd): substitute remaining 'Neon' references with 'Railway phd-postgres-ssot' (refs #446 #380 #498)

### DIFF
--- a/docs/phd/AUDIT_REPORT.md
+++ b/docs/phd/AUDIT_REPORT.md
@@ -14,7 +14,7 @@
 | Глав всего | 69 | — | OK |
 | Глав с иллюстрациями | **69 / 69** | универсальный стиль | ✅ |
 | Полностью написанных глав (≥ 1500 строк) | **3** | R3 ≥1500 строк | ❌ дописать 66 |
-| Deferred-stubs (Neon-pending) | 21 | R5 honest | ⚠️ ждут Neon |
+| Deferred-stubs (Railway-pending) | 21 | R5 honest | ⚠️ ждут Railway phd-postgres-ssot |
 | Реальные но «тонкие» главы | 45 | R3 не выполнен | ⚠️ дописать |
 | Приложения | 14 | — | OK |
 | Приложения с иллюстрациями | 9 / 14 | — | ⚠️ нет 5 |
@@ -43,7 +43,7 @@ https://raw.githubusercontent.com/gHashTag/trios/feat/phd-v5-tectonic-fix/assets
 | F — FPGA Bitstream | `F-fpga-bitstream.tex` | требуется новая (макет bitstream-архива) |
 | H — Zenodo DOI | `H-zenodo-doi.tex` | `app-h-zenodo-doi-registry.png` (есть в репо, не подключена) |
 | K — Agent Memory | `K-agent-memory.tex` | требуется новая (схема памяти 27-агентного улья) |
-| L — Pollen Channel | `L-pollen-channel.tex` | требуется новая (Pollen-канал ↔ Neon flow) |
+| L — Pollen Channel | `L-pollen-channel.tex` | требуется новая (Pollen-канал ↔ Railway flow) |
 
 **Действие:** 2 иллюстрации (C, H) уже лежат в `assets/illustrations/` — нужно только подключить через `\includegraphics`. 3 иллюстрации (F, K, L) нужно сгенерировать.
 
@@ -61,7 +61,7 @@ https://raw.githubusercontent.com/gHashTag/trios/feat/phd-v5-tectonic-fix/assets
 
 ### 3.2 ⚠️ Реальная проза, но ниже R3-floor — 45 глав
 
-Эти главы содержат настоящий текст (1500-2400 слов из Neon), но **меньше 1500 строк** LaTeX. Самые слабые:
+Эти главы содержат настоящий текст (1500-2400 слов из Railway phd-postgres-ssot), но **меньше 1500 строк** LaTeX. Самые слабые:
 
 | Файл | Строк | Слов |
 |---|---|---|
@@ -74,7 +74,7 @@ https://raw.githubusercontent.com/gHashTag/trios/feat/phd-v5-tectonic-fix/assets
 
 **Действие R3:** растянуть каждую до ≥1500 строк/≥1500 слов добавлением: (a) формальных доказательств, (b) Coq-цитат, (c) Falsification §, (d) Rule-of-Three Brain/Throne/Proof.
 
-### 3.3 ⚠️ Deferred-stubs (ждут Neon) — 21 глава
+### 3.3 ⚠️ Deferred-stubs (ждут Railway phd-postgres-ssot) — 21 глава
 
 ```
 02-golden-cut         11-vesica-piscis     22-e8-symmetry
@@ -88,7 +88,7 @@ https://raw.githubusercontent.com/gHashTag/trios/feat/phd-v5-tectonic-fix/assets
                                            33-epilogue
 ```
 
-Все 21 — честные R5-плейсхолдеры на 117 строк. Источник правды: `ssot.chapters` (Neon, project IGLA). Будут заменены `tri phd export-neon` как только Neon compute-time quota восстановится или Railway hot-mirror `c5f37b42-832a-4acd-9749-381761c94957` поднимется.
+Все 21 — честные R5-плейсхолдеры на 117 строк. Источник правды: `ssot.chapters` (Railway phd-postgres-ssot, project IGLA). Будут заменены `tri phd export-railway` как только Railway phd-postgres-ssot quota восстановится или hot-mirror `c5f37b42-832a-4acd-9749-381761c94957` поднимется.
 
 ---
 
@@ -104,7 +104,7 @@ https://raw.githubusercontent.com/gHashTag/trios/feat/phd-v5-tectonic-fix/assets
 
 | Приоритет | Задача | Lane |
 |---|---|---|
-| P0 | Поднять Neon или Railway hot-mirror → импорт 21 deferred-stub в реальные главы | LN |
+| P0 | Поднять Railway phd-postgres-ssot hot-mirror → импорт 21 deferred-stub в реальные главы | LN |
 | P0 | Дописать 45 «тонких» глав до R3 floor | L1..L45 |
 | P1 | Подключить иллюстрации в C, H | LF |
 | P1 | Сгенерировать 3 новые иллюстрации (F, K, L) | LF |

--- a/docs/phd/appendix/E-lexicon.tex
+++ b/docs/phd/appendix/E-lexicon.tex
@@ -3,7 +3,7 @@
 % Original file moved to docs/phd/quarantine/E-lexicon.tex (LaTeX parse error).
 % R5-honest placeholder: source of truth for this chapter's prose is
 % the Railway PostgreSQL table `ssot.chapters` (migration manifest: gHashTag/trios#380).
-% Do NOT hand-edit this stub; let `trios-phd export-neon` re-render from
+% Do NOT hand-edit this stub; let `trios-phd export-railway` re-render from
 % the SSOT once the Railway PostgreSQL phd-postgres-ssot service is provisioned.
 % ============================================================
 
@@ -35,7 +35,7 @@ could not auto-repair via the mechanical fixer
 (\texttt{trios-phd fix-common-latex}). Per the project's R5 honesty
 discipline we refuse to ship lossy or fabricated prose; the chapter is
 therefore quarantined and will be re-rendered from Railway PostgreSQL phd-postgres-ssot by the
-\texttt{trios-phd export-neon} subcommand once one of the following
+\texttt{trios-phd export-railway} subcommand once one of the following
 conditions is met:
 \begin{enumerate}
 \item The Railway PostgreSQL phd-postgres-ssot service is provisioned

--- a/docs/phd/appendix/K-agent-memory.tex
+++ b/docs/phd/appendix/K-agent-memory.tex
@@ -3,7 +3,7 @@
 % Original file moved to docs/phd/quarantine/K-agent-memory.tex (LaTeX parse error).
 % R5-honest placeholder: source of truth for this chapter's prose is
 % the Railway PostgreSQL table `ssot.chapters` (migration manifest: gHashTag/trios#380).
-% Do NOT hand-edit this stub; let `trios-phd export-neon` re-render from
+% Do NOT hand-edit this stub; let `trios-phd export-railway` re-render from
 % the SSOT once the Railway PostgreSQL phd-postgres-ssot service is provisioned.
 % ============================================================
 
@@ -35,7 +35,7 @@ could not auto-repair via the mechanical fixer
 (\texttt{trios-phd fix-common-latex}). Per the project's R5 honesty
 discipline we refuse to ship lossy or fabricated prose; the chapter is
 therefore quarantined and will be re-rendered from Railway PostgreSQL phd-postgres-ssot by the
-\texttt{trios-phd export-neon} subcommand once one of the following
+\texttt{trios-phd export-railway} subcommand once one of the following
 conditions is met:
 \begin{enumerate}
 \item The Railway PostgreSQL phd-postgres-ssot service is provisioned

--- a/docs/phd/appendix/L-pollen-channel.tex
+++ b/docs/phd/appendix/L-pollen-channel.tex
@@ -3,7 +3,7 @@
 % Original file moved to docs/phd/quarantine/L-pollen-channel.tex (LaTeX parse error).
 % R5-honest placeholder: source of truth for this chapter's prose is
 % the Railway PostgreSQL table `ssot.chapters` (migration manifest: gHashTag/trios#380).
-% Do NOT hand-edit this stub; let `trios-phd export-neon` re-render from
+% Do NOT hand-edit this stub; let `trios-phd export-railway` re-render from
 % the SSOT once the Railway PostgreSQL phd-postgres-ssot service is provisioned.
 % ============================================================
 
@@ -35,7 +35,7 @@ could not auto-repair via the mechanical fixer
 (\texttt{trios-phd fix-common-latex}). Per the project's R5 honesty
 discipline we refuse to ship lossy or fabricated prose; the chapter is
 therefore quarantined and will be re-rendered from Railway PostgreSQL phd-postgres-ssot by the
-\texttt{trios-phd export-neon} subcommand once one of the following
+\texttt{trios-phd export-railway} subcommand once one of the following
 conditions is met:
 \begin{enumerate}
 \item The Railway PostgreSQL phd-postgres-ssot service is provisioned

--- a/docs/phd/chapters/15-kepler-solids.tex
+++ b/docs/phd/chapters/15-kepler-solids.tex
@@ -154,7 +154,7 @@ criterion. The victory criterion requires step
 \(< 1.85\) (Gate-2) [6].
 
 \section{3. Railway PostgreSQL Write-Back
-Architecture}\label{neon-write-back-architecture}
+Architecture}\label{railway-write-back-architecture}
 
 \subsection{3.1 Database
 Schema}\label{database-schema}

--- a/docs/phd/chapters/ch_15.tex
+++ b/docs/phd/chapters/ch_15.tex
@@ -1,5 +1,5 @@
 % ============================================================
-% Auto-generated from docs/golden-sunflowers/ch-15-bpb-benchmark-neon-write.md
+% Auto-generated from docs/golden-sunflowers/ch-15-bpb-benchmark-railway-write.md
 % Source of truth: Railway phd-postgres-ssot ssot.chapters (gHashTag/trios#380)
 % ============================================================
 
@@ -56,7 +56,7 @@ The proof of INV-1 proceeds by establishing a Lyapunov function \(V(t) = \text{B
 
 INV-1 applies only for \(t \geq t_0 = 100\). Before that, the learning rate ramp can cause temporary BPB increases. This is consistent with the \texttt{refutation\_pre\_warmup} theorem in Ch.21 (INV-7), which proves that a run at step 100 with BPB \(= 1.40\) does not satisfy the victory criterion. The victory criterion requires step \(\geq 4000\) and BPB \(< 1.5\) (Gate-3) or BPB \(< 1.85\) (Gate-2) {[}6{]}.
 
-\section{3. Railway PostgreSQL Write-Back Architecture}\label{neon-write-back-architecture}
+\section{3. Railway PostgreSQL Write-Back Architecture}\label{railway-write-back-architecture}
 
 \subsection{3.1 Database Schema}\label{database-schema}
 

--- a/docs/phd/main.tex
+++ b/docs/phd/main.tex
@@ -351,7 +351,7 @@
 \include{chapters/32-conclusion}
 \include{chapters/33-epilogue}
 
-% --- Trinity S³AI strand (Ch.0..Ch.34) materialised from Neon ssot.chapters ---
+% --- Trinity S³AI strand (Ch.0..Ch.34) materialised from Railway phd-postgres-ssot (ssot.chapters) ---
 \part{Trinity S³AI Strand}
 \include{chapters/ch_00}
 \include{chapters/ch_01}

--- a/docs/phd/v5-hero-fullwidth.md
+++ b/docs/phd/v5-hero-fullwidth.md
@@ -36,7 +36,7 @@ pipeline. The goal: every chapter's hero illustration is rendered as the
 
 ## Operational notes
 
-- Schema in Neon uses `body_md`, `body_pdf_url`, `illustration_url`,
+- Schema in Railway phd-postgres-ssot uses `body_md`, `body_pdf_url`, `illustration_url`,
   `illustration_path` (snake_case). There is no `slug` column.
 - `ch_num` is **text** (`Ch.1`, `App.A`, `FA.07`, `FM.01`, `AP.A`),
   not an integer — never use `WHERE ch_num BETWEEN 1 AND 44`.


### PR DESCRIPTION
Closes #522
Part of #446
Part of #380

## chore(phd): substitute remaining `Neon` references with `Railway phd-postgres-ssot`

Documentation-only post-migration cleanup. The PhD SSOT lives on Railway `phd-postgres-ssot` (`interchange.proxy.rlwy.net:30942`, project IGLA, db `railway`) since the schema DDL was applied. Remaining `Neon` / `export-neon` strings in `docs/phd/*` are stale and contradict the active source of truth.

### Idempotent

This patch touches only documentation strings. **No** Rust code, training pipeline, or CI workflow is altered.

### Files changed (8)

```
docs/phd/AUDIT_REPORT.md
docs/phd/appendix/E-lexicon.tex
docs/phd/appendix/K-agent-memory.tex
docs/phd/appendix/L-pollen-channel.tex
docs/phd/chapters/15-kepler-solids.tex
docs/phd/chapters/ch_15.tex
docs/phd/main.tex
docs/phd/v5-hero-fullwidth.md
```

17 insertions, 17 deletions.

### Refs

- #446 (PhD pipeline reproducibility, observability)
- #380 (PhD SSOT migration)
- #498 (Railway phd-postgres-ssot provisioning)

Anchor: φ² + φ⁻² = 3 · TRINITY · NEVER STOP
