### PR TITLE
feat(phd/ui): PhD SSOT Dashboard — chapters table, duplicates, RAG coverage (R1 Rust/Axum/HTMX)

### DIFF
--- a/crates/phd-dashboard/Cargo.toml
+++ b/crates/phd-dashboard/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "phd-dashboard"
+version = "0.1.0"
+edition = "2021"
+authors = ["Dmitrii Vasilev <ORCID:0009-0008-4294-6159>"]
+description = "PhD SSOT live dashboard — chapters, RAG coverage, duplicates"
+
+[[bin]]
+name = "phd-dashboard"
+path = "src/main.rs"
+
+[dependencies]
+axum = { version = "0.7", features = ["macros"] }
+tokio = { version = "1", features = ["full"] }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+askama = { version = "0.12", features = ["with-axum"] }
+askama_axum = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+anyhow = "1"
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/phd-dashboard/src/main.rs
+++ b/crates/phd-dashboard/src/main.rs
@@ -1,0 +1,270 @@
+//! PhD SSOT Dashboard — Axum + HTMX + Askama
+//! R1: pure Rust, no .py/.sh, no JS frameworks
+//! φ² + φ⁻² = 3 · TRINITY
+//!
+//! ENV: DATABASE_URL="$RAILWAY_SSOT_URL"   (set via Railway service variables)
+//!      PORT=3030 (default)
+
+use anyhow::Result;
+use askama::Template;
+use askama_axum::IntoResponse;
+use axum::{
+    extract::State,
+    routing::get,
+    Router,
+};
+use serde::Serialize;
+use std::sync::Arc;
+use tokio_postgres::NoTls;
+use tracing_subscriber::EnvFilter;
+
+// ─── DB pool (simple Arc<tokio_postgres::Client>) ────────────────────────────
+
+type Db = Arc<tokio_postgres::Client>;
+
+// ─── Data structs ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Clone)]
+struct ChapterRow {
+    chapter_slug: String,
+    chapter_no: i32,
+    kind: String,
+    title: String,
+    line_count: i32,
+    r3_full: bool,
+    has_figure: bool,
+    theorem_count: i64,
+    updated_at: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct DuplicateRow {
+    chapter_slug: String,
+    title: String,
+    dup_count: i64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct RagRow {
+    chapter_slug: String,
+    total_chunks: i64,
+    embedded_chunks: i64,
+    pct: f64,
+    last_embedded: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct Stats {
+    total_chapters: i64,
+    r3_ok: i64,
+    with_figure: i64,
+    total_theorems: i64,
+    rag_total: i64,
+    rag_embedded: i64,
+    rag_pct: f64,
+    duplicate_slugs: i64,
+}
+
+// ─── Askama templates ─────────────────────────────────────────────────────────
+
+#[derive(Template)]
+#[template(path = "index.html")]
+struct IndexTemplate {
+    stats: Stats,
+    chapters: Vec<ChapterRow>,
+    duplicates: Vec<DuplicateRow>,
+    rag: Vec<RagRow>,
+}
+
+// ─── DB queries ───────────────────────────────────────────────────────────────
+
+async fn fetch_chapters(db: &tokio_postgres::Client) -> Result<Vec<ChapterRow>> {
+    let rows = db
+        .query(
+            "SELECT chapter_slug, chapter_no, kind, title, \
+                    COALESCE(line_count,0) AS line_count, \
+                    (COALESCE(line_count,0) >= 1500) AS r3_full, \
+                    (EXISTS(SELECT 1 FROM ssot.chapter_figures f WHERE f.chapter_slug = c.chapter_slug)) AS has_figure, \
+                    (SELECT COUNT(*) FROM ssot.theorems t WHERE t.chapter_slug = c.chapter_slug) AS theorem_count, \
+                    updated_at::text \
+             FROM ssot.chapters c \
+             ORDER BY chapter_no",
+            &[],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|r| ChapterRow {
+            chapter_slug: r.get(0),
+            chapter_no: r.get(1),
+            kind: r.get(2),
+            title: r.get(3),
+            line_count: r.get::<_, i32>(4),
+            r3_full: r.get(5),
+            has_figure: r.get(6),
+            theorem_count: r.get(7),
+            updated_at: r.get::<_, String>(8),
+        })
+        .collect())
+}
+
+async fn fetch_duplicates(db: &tokio_postgres::Client) -> Result<Vec<DuplicateRow>> {
+    // Дубликаты по title (нормализованному)
+    let rows = db
+        .query(
+            "SELECT chapter_slug, title, cnt FROM (\
+               SELECT chapter_slug, title, \
+                      COUNT(*) OVER (PARTITION BY lower(trim(title))) AS cnt \
+               FROM ssot.chapters\
+             ) sub WHERE cnt > 1 ORDER BY cnt DESC, title",
+            &[],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|r| DuplicateRow {
+            chapter_slug: r.get(0),
+            title: r.get(1),
+            dup_count: r.get(2),
+        })
+        .collect())
+}
+
+async fn fetch_rag(db: &tokio_postgres::Client) -> Result<Vec<RagRow>> {
+    let rows = db
+        .query(
+            "SELECT \
+                e.chapter_slug, \
+                COUNT(e.id)                                        AS total_chunks, \
+                COUNT(e.id) FILTER (WHERE e.embedding IS NOT NULL) AS embedded_chunks, \
+                ROUND(100.0 * COUNT(e.id) FILTER (WHERE e.embedding IS NOT NULL) \
+                      / NULLIF(COUNT(e.id),0), 1)                  AS pct, \
+                COALESCE(MAX(e.embedded_at)::text, 'pending')      AS last_embedded \
+             FROM ssot.embeddings e \
+             GROUP BY e.chapter_slug \
+             ORDER BY e.chapter_slug",
+            &[],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|r| RagRow {
+            chapter_slug: r.get(0),
+            total_chunks: r.get(1),
+            embedded_chunks: r.get(2),
+            pct: r.get::<_, f64>(3),
+            last_embedded: r.get(4),
+        })
+        .collect())
+}
+
+async fn fetch_stats(db: &tokio_postgres::Client) -> Result<Stats> {
+    let row = db
+        .query_one(
+            "SELECT \
+                (SELECT COUNT(*) FROM ssot.chapters) AS total_chapters, \
+                (SELECT COUNT(*) FROM ssot.chapters WHERE COALESCE(line_count,0) >= 1500) AS r3_ok, \
+                (SELECT COUNT(*) FROM ssot.chapter_figures) AS with_figure, \
+                (SELECT COUNT(*) FROM ssot.theorems) AS total_theorems, \
+                (SELECT COUNT(*) FROM ssot.embeddings) AS rag_total, \
+                (SELECT COUNT(*) FROM ssot.embeddings WHERE embedding IS NOT NULL) AS rag_embedded, \
+                (SELECT COUNT(*) FROM ( \
+                   SELECT chapter_slug FROM ssot.chapters \
+                   GROUP BY lower(trim(title)) HAVING COUNT(*) > 1 \
+                ) d) AS duplicate_slugs",
+            &[],
+        )
+        .await?;
+    let rag_total: i64 = row.get(4);
+    let rag_embedded: i64 = row.get(5);
+    let rag_pct = if rag_total > 0 {
+        (rag_embedded as f64 / rag_total as f64) * 100.0
+    } else {
+        0.0
+    };
+    Ok(Stats {
+        total_chapters: row.get(0),
+        r3_ok: row.get(1),
+        with_figure: row.get(2),
+        total_theorems: row.get(3),
+        rag_total,
+        rag_embedded,
+        rag_pct,
+        duplicate_slugs: row.get(6),
+    })
+}
+
+// ─── Handlers ─────────────────────────────────────────────────────────────────
+
+async fn index(State(db): State<Db>) -> impl IntoResponse {
+    let (stats, chapters, duplicates, rag) = tokio::join!(
+        fetch_stats(&db),
+        fetch_chapters(&db),
+        fetch_duplicates(&db),
+        fetch_rag(&db),
+    );
+    IndexTemplate {
+        stats: stats.unwrap_or(Stats {
+            total_chapters: 0, r3_ok: 0, with_figure: 0,
+            total_theorems: 0, rag_total: 0, rag_embedded: 0,
+            rag_pct: 0.0, duplicate_slugs: 0,
+        }),
+        chapters: chapters.unwrap_or_default(),
+        duplicates: duplicates.unwrap_or_default(),
+        rag: rag.unwrap_or_default(),
+    }
+}
+
+// HTMX partial — refresh only chapters table
+async fn htmx_chapters(State(db): State<Db>) -> impl IntoResponse {
+    #[derive(Template)]
+    #[template(path = "partials/chapters_table.html")]
+    struct T { chapters: Vec<ChapterRow> }
+    T { chapters: fetch_chapters(&db).await.unwrap_or_default() }
+}
+
+// HTMX partial — refresh only RAG table
+async fn htmx_rag(State(db): State<Db>) -> impl IntoResponse {
+    #[derive(Template)]
+    #[template(path = "partials/rag_table.html")]
+    struct T { rag: Vec<RagRow> }
+    T { rag: fetch_rag(&db).await.unwrap_or_default() }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    // φ² + φ⁻² = 3  anchor
+    let phi: f64 = (1.0 + 5.0_f64.sqrt()) / 2.0;
+    assert!((phi * phi + 1.0 / (phi * phi) - 3.0).abs() < 1e-12, "Trinity anchor");
+
+    let database_url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    let (client, conn) = tokio_postgres::connect(&database_url, NoTls).await?;
+    tokio::spawn(async move {
+        if let Err(e) = conn.await { eprintln!("db conn error: {e}"); }
+    });
+
+    let db: Db = Arc::new(client);
+    let port: u16 = std::env::var("PORT")
+        .unwrap_or_else(|_| "3030".into())
+        .parse()
+        .unwrap_or(3030);
+
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/htmx/chapters", get(htmx_chapters))
+        .route("/htmx/rag", get(htmx_rag))
+        .with_state(db);
+
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    tracing::info!("PhD SSOT Dashboard listening on http://{addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/crates/phd-dashboard/templates/index.html
+++ b/crates/phd-dashboard/templates/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PhD SSOT Dashboard · v5.1.0</title>
+  <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+  <style>
+    :root {
+      --gold: #c9a84c; --gold-light: #f0d080; --bg: #0f0f0f; --surface: #1a1a1a;
+      --surface2: #242424; --text: #e8e8e8; --muted: #888; --green: #4caf7d;
+      --red: #e05c5c; --blue: #5c9fe0; --radius: 8px;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: var(--bg); color: var(--text); font-family: 'JetBrains Mono', 'Fira Mono', monospace; font-size: 13px; }
+    header { background: var(--surface); border-bottom: 2px solid var(--gold); padding: 16px 24px; display: flex; align-items: center; gap: 16px; }
+    header h1 { font-size: 18px; color: var(--gold); letter-spacing: 1px; }
+    header .anchor { color: var(--muted); font-size: 11px; }
+    .container { max-width: 1400px; margin: 0 auto; padding: 24px; }
+    .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin-bottom: 32px; }
+    .stat-card { background: var(--surface); border: 1px solid var(--surface2); border-radius: var(--radius); padding: 16px; text-align: center; }
+    .stat-card .value { font-size: 28px; font-weight: bold; color: var(--gold-light); }
+    .stat-card .label { color: var(--muted); font-size: 11px; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .stat-card.warn .value { color: var(--red); }
+    .stat-card.ok .value { color: var(--green); }
+    section { margin-bottom: 40px; }
+    section h2 { color: var(--gold); font-size: 14px; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; padding-bottom: 6px; border-bottom: 1px solid var(--surface2); display: flex; align-items: center; gap: 10px; }
+    section h2 .refresh-btn { font-size: 11px; color: var(--blue); cursor: pointer; background: none; border: 1px solid var(--blue); border-radius: 4px; padding: 2px 8px; }
+    table { width: 100%; border-collapse: collapse; background: var(--surface); border-radius: var(--radius); overflow: hidden; }
+    thead tr { background: var(--surface2); }
+    th { padding: 10px 12px; text-align: left; color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; font-weight: normal; }
+    td { padding: 9px 12px; border-top: 1px solid var(--surface2); vertical-align: middle; }
+    tr:hover td { background: rgba(201,168,76,0.05); }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 99px; font-size: 10px; font-weight: bold; }
+    .badge-ok { background: rgba(76,175,125,0.2); color: var(--green); }
+    .badge-warn { background: rgba(224,92,92,0.2); color: var(--red); }
+    .badge-blue { background: rgba(92,159,224,0.2); color: var(--blue); }
+    .badge-gold { background: rgba(201,168,76,0.2); color: var(--gold); }
+    .kind-fa { color: var(--gold); }
+    .kind-trinity { color: var(--blue); }
+    .kind-appendix { color: var(--muted); }
+    .progress-bar { background: var(--surface2); border-radius: 99px; height: 6px; width: 80px; overflow: hidden; display: inline-block; vertical-align: middle; margin-left: 8px; }
+    .progress-fill { height: 100%; background: var(--green); border-radius: 99px; }
+    .dup-warning { background: rgba(224,92,92,0.1); border: 1px solid rgba(224,92,92,0.3); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 16px; color: var(--red); }
+    .no-dups { color: var(--green); padding: 12px; text-align: center; background: var(--surface); border-radius: var(--radius); }
+    .slug { font-family: monospace; color: var(--gold-light); font-size: 11px; }
+    footer { text-align: center; color: var(--muted); padding: 24px; font-size: 11px; border-top: 1px solid var(--surface2); }
+  </style>
+</head>
+<body>
+<header>
+  <div>
+    <h1>📚 PhD SSOT Dashboard</h1>
+    <span class="anchor">φ² + φ⁻² = 3 · v5.1.0 · BAAI/bge-m3 · Railway PostgreSQL</span>
+  </div>
+</header>
+
+<div class="container">
+
+  <!-- STATS GRID -->
+  <div class="stats-grid">
+    <div class="stat-card">
+      <div class="value">{{ stats.total_chapters }}</div>
+      <div class="label">Chapters</div>
+    </div>
+    <div class="stat-card {% if stats.r3_ok == stats.total_chapters %}ok{% else %}warn{% endif %}">
+      <div class="value">{{ stats.r3_ok }}/{{ stats.total_chapters }}</div>
+      <div class="label">R3 ≥ 1500 lines</div>
+    </div>
+    <div class="stat-card">
+      <div class="value">{{ stats.with_figure }}</div>
+      <div class="label">With figure</div>
+    </div>
+    <div class="stat-card">
+      <div class="value">{{ stats.total_theorems }}</div>
+      <div class="label">Theorems</div>
+    </div>
+    <div class="stat-card {% if stats.rag_pct >= 100.0 %}ok{% else %}warn{% endif %}">
+      <div class="value">{{ stats.rag_pct | round }}%</div>
+      <div class="label">RAG embedded</div>
+    </div>
+    <div class="stat-card {% if stats.duplicate_slugs == 0 %}ok{% else %}warn{% endif %}">
+      <div class="value">{{ stats.duplicate_slugs }}</div>
+      <div class="label">Duplicate titles</div>
+    </div>
+  </div>
+
+  <!-- DUPLICATES -->
+  <section>
+    <h2>⚠️ Duplicate Titles</h2>
+    {% if duplicates.is_empty() %}
+      <div class="no-dups">✅ No duplicate chapter titles found</div>
+    {% else %}
+      <div class="dup-warning">{{ duplicates.len() }} chapters share a title with another chapter — review for SSOT violations</div>
+      <table>
+        <thead><tr><th>Slug</th><th>Title</th><th>Count</th></tr></thead>
+        <tbody>
+        {% for d in duplicates %}
+          <tr>
+            <td><span class="slug">{{ d.chapter_slug }}</span></td>
+            <td>{{ d.title }}</td>
+            <td><span class="badge badge-warn">{{ d.dup_count }}×</span></td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+  </section>
+
+  <!-- CHAPTERS TABLE -->
+  <section>
+    <h2>
+      📖 Chapters ({{ chapters.len() }})
+      <button class="refresh-btn"
+              hx-get="/htmx/chapters"
+              hx-target="#chapters-table"
+              hx-swap="outerHTML">⟳ refresh</button>
+    </h2>
+    {% include "partials/chapters_table.html" %}
+  </section>
+
+  <!-- RAG COVERAGE -->
+  <section>
+    <h2>
+      🧠 RAG Coverage · BAAI/bge-m3 · dim=1024
+      <button class="refresh-btn"
+              hx-get="/htmx/rag"
+              hx-target="#rag-table"
+              hx-swap="outerHTML">⟳ refresh</button>
+    </h2>
+    {% include "partials/rag_table.html" %}
+  </section>
+
+</div>
+
+<footer>
+  Дмитрий Васильев · ORCID 0009-0008-4294-6159 · DOI 10.5281/zenodo.19227877 · φ² + φ⁻² = 3
+</footer>
+</body>
+</html>

--- a/crates/phd-dashboard/templates/partials/chapters_table.html
+++ b/crates/phd-dashboard/templates/partials/chapters_table.html
@@ -1,0 +1,50 @@
+<table id="chapters-table">
+  <thead>
+    <tr>
+      <th>#</th>
+      <th>Slug</th>
+      <th>Kind</th>
+      <th>Title</th>
+      <th>Lines</th>
+      <th>R3</th>
+      <th>Figure</th>
+      <th>Theorems</th>
+      <th>Updated</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for ch in chapters %}
+    <tr>
+      <td style="color:var(--muted)">{{ ch.chapter_no }}</td>
+      <td><span class="slug">{{ ch.chapter_slug }}</span></td>
+      <td>
+        {% if ch.kind == "fa" %}
+          <span class="badge badge-gold">FA</span>
+        {% else if ch.kind == "trinity" %}
+          <span class="badge badge-blue">Trinity</span>
+        {% else %}
+          <span class="badge" style="background:var(--surface2);color:var(--muted)">App</span>
+        {% endif %}
+      </td>
+      <td>{{ ch.title }}</td>
+      <td style="text-align:right">{{ ch.line_count }}</td>
+      <td>
+        {% if ch.r3_full %}
+          <span class="badge badge-ok">✓</span>
+        {% else %}
+          <span class="badge badge-warn">✗</span>
+        {% endif %}
+      </td>
+      <td>
+        {% if ch.has_figure %}
+          <span class="badge badge-ok">✓</span>
+        {% else %}
+          <span class="badge badge-warn">✗</span>
+        {% endif %}
+      </td>
+      <td style="text-align:center">{{ ch.theorem_count }}</td>
+      <td style="color:var(--muted);font-size:11px">{{ ch.updated_at | truncate(10) }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/crates/phd-dashboard/templates/partials/rag_table.html
+++ b/crates/phd-dashboard/templates/partials/rag_table.html
@@ -1,0 +1,29 @@
+<table id="rag-table">
+  <thead>
+    <tr>
+      <th>Chapter</th>
+      <th>Total chunks</th>
+      <th>Embedded</th>
+      <th>Coverage</th>
+      <th>Last embedded</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for r in rag %}
+    <tr>
+      <td><span class="slug">{{ r.chapter_slug }}</span></td>
+      <td style="text-align:right">{{ r.total_chunks }}</td>
+      <td style="text-align:right">{{ r.embedded_chunks }}</td>
+      <td>
+        <span {% if r.pct >= 100.0 %}class="badge badge-ok"{% else %}class="badge badge-warn"{% endif %}>
+          {{ r.pct }}%
+        </span>
+        <span class="progress-bar">
+          <span class="progress-fill" style="width:{{ r.pct }}%"></span>
+        </span>
+      </td>
+      <td style="color:var(--muted);font-size:11px">{{ r.last_embedded | truncate(19) }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
## PhD SSOT Live Dashboard

Rust-only (R1) web dashboard for the Railway PostgreSQL SSOT.

### Features
- **Stats panel** — total chapters, R3 compliance, figures, theorems, RAG %, duplicate count
- **Duplicate detector** — finds chapters sharing `lower(trim(title))`, flags SSOT violations
- **Chapters table** — all rows from `ssot.chapters` with R3/figure/theorem status badges
- **RAG coverage** — per-chapter chunk count + embedded count + progress bar
- **HTMX live refresh** — `/htmx/chapters` and `/htmx/rag` partial updates without full reload

### Stack (R1 enforced)
- `axum 0.7` — HTTP server
- `askama` — compile-time HTML templates
- `htmx 1.9` — CDN, zero handwritten JS
- `tokio-postgres` — direct Railway PostgreSQL
- `fastembed` not required here (embed_rag.rs handles that separately)

### Run locally
```bash
DATABASE_URL="$RAILWAY_SSOT_URL" \
PORT=3030 \
cargo run -p phd-dashboard --release
# open http://localhost:3030
```

### Duplicate check query
```sql
SELECT chapter_slug, title, COUNT(*) OVER (PARTITION BY lower(trim(title))) AS cnt
FROM ssot.chapters
HAVING cnt > 1;
```

Trinity anchor: φ² + φ⁻² = 3 · Closes #513 (dashboard criterion)

Author: Дмитрий Васильев · ORCID 0009-0008-4294-6159 · DOI 10.5281/zenodo.19227877
