### PR TITLE
fix(phd-dashboard): register in workspace + askama filter & numeric cast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "crates/trinity-extract",
     # PhD monograph build / audit / bibliography / coq-map / reproduce (Rust-only, R1)
     "crates/trios-phd",
+    "crates/phd-dashboard",
     # LT Phase D — page-count gate witness for trios#265 (Rust-only, R1)
     "tools/page_gate",
     "tools/acm_ae_check",

--- a/crates/phd-dashboard/src/main.rs
+++ b/crates/phd-dashboard/src/main.rs
@@ -62,6 +62,7 @@ struct Stats {
     rag_total: i64,
     rag_embedded: i64,
     rag_pct: f64,
+    rag_pct_int: i64,
     duplicate_slugs: i64,
 }
 
@@ -103,7 +104,10 @@ async fn fetch_chapters(db: &tokio_postgres::Client) -> Result<Vec<ChapterRow>> 
             r3_full: r.get(5),
             has_figure: r.get(6),
             theorem_count: r.get(7),
-            updated_at: r.get::<_, String>(8),
+            updated_at: {
+                let s: String = r.get(8);
+                s.chars().take(10).collect() // YYYY-MM-DD
+            },
         })
         .collect())
 }
@@ -137,8 +141,8 @@ async fn fetch_rag(db: &tokio_postgres::Client) -> Result<Vec<RagRow>> {
                 e.chapter_slug, \
                 COUNT(e.id)                                        AS total_chunks, \
                 COUNT(e.id) FILTER (WHERE e.embedding IS NOT NULL) AS embedded_chunks, \
-                ROUND(100.0 * COUNT(e.id) FILTER (WHERE e.embedding IS NOT NULL) \
-                      / NULLIF(COUNT(e.id),0), 1)                  AS pct, \
+                (ROUND(100.0 * COUNT(e.id) FILTER (WHERE e.embedding IS NOT NULL) \
+                      / NULLIF(COUNT(e.id),0), 1))::float8           AS pct, \
                 COALESCE(MAX(e.embedded_at)::text, 'pending')      AS last_embedded \
              FROM ssot.embeddings e \
              GROUP BY e.chapter_slug \
@@ -153,7 +157,10 @@ async fn fetch_rag(db: &tokio_postgres::Client) -> Result<Vec<RagRow>> {
             total_chunks: r.get(1),
             embedded_chunks: r.get(2),
             pct: r.get::<_, f64>(3),
-            last_embedded: r.get(4),
+            last_embedded: {
+                let s: String = r.get(4);
+                s.chars().take(19).collect() // YYYY-MM-DD HH:MM:SS
+            },
         })
         .collect())
 }
@@ -190,6 +197,7 @@ async fn fetch_stats(db: &tokio_postgres::Client) -> Result<Stats> {
         rag_total,
         rag_embedded,
         rag_pct,
+        rag_pct_int: rag_pct.round() as i64,
         duplicate_slugs: row.get(6),
     })
 }
@@ -207,7 +215,7 @@ async fn index(State(db): State<Db>) -> impl IntoResponse {
         stats: stats.unwrap_or(Stats {
             total_chapters: 0, r3_ok: 0, with_figure: 0,
             total_theorems: 0, rag_total: 0, rag_embedded: 0,
-            rag_pct: 0.0, duplicate_slugs: 0,
+            rag_pct: 0.0, rag_pct_int: 0, duplicate_slugs: 0,
         }),
         chapters: chapters.unwrap_or_default(),
         duplicates: duplicates.unwrap_or_default(),

--- a/crates/phd-dashboard/templates/index.html
+++ b/crates/phd-dashboard/templates/index.html
@@ -76,7 +76,7 @@
       <div class="label">Theorems</div>
     </div>
     <div class="stat-card {% if stats.rag_pct >= 100.0 %}ok{% else %}warn{% endif %}">
-      <div class="value">{{ stats.rag_pct | round }}%</div>
+      <div class="value">{{ stats.rag_pct_int }}%</div>
       <div class="label">RAG embedded</div>
     </div>
     <div class="stat-card {% if stats.duplicate_slugs == 0 %}ok{% else %}warn{% endif %}">

--- a/crates/phd-dashboard/templates/partials/chapters_table.html
+++ b/crates/phd-dashboard/templates/partials/chapters_table.html
@@ -43,7 +43,7 @@
         {% endif %}
       </td>
       <td style="text-align:center">{{ ch.theorem_count }}</td>
-      <td style="color:var(--muted);font-size:11px">{{ ch.updated_at | truncate(10) }}</td>
+      <td style="color:var(--muted);font-size:11px">{{ ch.updated_at }}</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/crates/phd-dashboard/templates/partials/rag_table.html
+++ b/crates/phd-dashboard/templates/partials/rag_table.html
@@ -22,7 +22,7 @@
           <span class="progress-fill" style="width:{{ r.pct }}%"></span>
         </span>
       </td>
-      <td style="color:var(--muted);font-size:11px">{{ r.last_embedded | truncate(19) }}</td>
+      <td style="color:var(--muted);font-size:11px">{{ r.last_embedded }}</td>
     </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary

Post-merge of #523, the `phd-dashboard` crate failed to build. Three bugs:

1. **Workspace registration missing.** `crates/phd-dashboard` was not listed in `[workspace] members` of root `Cargo.toml`. `cargo check -p phd-dashboard` errored: `package ID specification … did not match any packages`. Fix: add `"crates/phd-dashboard"` to members.
2. **Askama 0.12 derive macro rejected `| truncate(N)` and `| round` filters** with `E0609`. Fix: precompute in Rust — `rag_pct_int = rag_pct.round() as i64`, and `s.chars().take(N).collect::<String>()` for date trimming. Templates now use plain values.
3. **`tokio-postgres` could not deserialize SQL `ROUND(…, 2)` (`numeric`) into `f64`.** Fix: cast result to `::float8` in the SELECT.

## Verification

```
cargo build -p phd-dashboard --release   # OK
DATABASE_URL=… PORT=3030 ./target/release/phd-dashboard
curl -sI http://localhost:3030/          # HTTP 200, 43233 bytes
```

Stats panel: chapters indexed = 34, RAG 100% (374/374), duplicates = 0.

## R1 (Rust-only)

No Python, no shell scripts. Build & runtime fully Rust (`cargo`, Axum 0.7, Askama 0.12, tokio-postgres).

Closes #513

Anchor: φ² + φ⁻² = 3
