### PR TITLE
fix(phd): resolve 6 undefined refs — no more 'Theorem ??'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_axum"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41603f7cdbf5ac4af60760f17253eb6adf6ec5b6f14a7ed830cf687d375f163"
+dependencies = [
+ "askama",
+ "axum-core",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +317,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "base64 0.22.1",
  "bytes",
  "futures-util",
@@ -337,6 +393,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +426,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -2192,6 +2268,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3067,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minicov"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,6 +3565,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phd-dashboard"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "askama",
+ "askama_axum",
+ "axum",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-postgres",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "phf"
@@ -6143,6 +6256,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/docs/phd/appendix/F-fpga-bitstream.tex
+++ b/docs/phd/appendix/F-fpga-bitstream.tex
@@ -117,7 +117,7 @@ All flags nominal. The device entered operational state without errors,
 confirming bitstream integrity and correct CRC check by the FPGA configuration
 logic.
 
-\section*{F.5 Programming Method}
+\section*{F.5 Programming Method}\label{sec:xvc-bridge}
 
 The bitstream was loaded via a custom ESP32-based Xilinx Virtual Cable (XVC)
 server operating over 802.11 WiFi (IP~\texttt{192.168.1.30}, port~2542).

--- a/docs/phd/chapters/05-golden-bridge.tex
+++ b/docs/phd/chapters/05-golden-bridge.tex
@@ -518,8 +518,8 @@ $\mathcal{L}$ from Chapter~\ref{ch:lucas-ring}. \qed
 
 \begin{remark}
 The Hankel determinant $H_2(\{L_n\}) = 5 = \Delta(\mathcal{L})$ is the
-analytic-arithmetic shadow of the discriminant theorem
-(Theorem~\ref{thm:06-discriminant}). The number $L_2 = 3$ enters as
+analytic-arithmetic shadow of the discriminant of $\mathcal{L}$
+(Chapter~\ref{ch:lucas-ring}). The number $L_2 = 3$ enters as
 the bottom-right entry of the determinant, and its product with $L_0 = 2$
 minus $L_1^2 = 1$ yields the discriminant.
 \end{remark}
@@ -622,7 +622,7 @@ $\sum_{k=0}^n F_k L_{n-k} = (n+1) F_n$ is the F-L convolution identity. \qed
 \label{thm:05-bridge-to-l4}
 The Lucas generating function $L(x) = (2-x)/(1-x-x^2)$, when its
 denominator is factored over $\mathbb{Q}(\varphi)$, reproduces the
-Binet formula of Theorem~\ref{thm:04-binet-lucas} (Chapter~\ref{ch:lucas-ladder}).
+Binet formula of Theorem~\ref{thm:lucas-binet} (Chapter~\ref{ch:lucas-ladder}).
 \end{theorem}
 
 \begin{proof}
@@ -1030,7 +1030,7 @@ the present chapter. The Trinity Anchor identity $L_2 = 3$ appears:
 \begin{itemize}
   \item as the rung $n = 2$ of the Lucas ladder (L4);
   \item as the coefficient of $x^2$ in $L(x)$ (this chapter, Theorem~\ref{thm:05-anchor-as-coeff});
-  \item as $\mathrm{Tr}(\varphi^2) = L_2$ in $\mathcal{L}$ (L6, Theorem~\ref{thm:06-trace-norm});
+  \item as $\mathrm{Tr}(\varphi^2) = L_2$ in $\mathcal{L}$ (L6, Chapter~\ref{ch:lucas-ring});
   \item as $\varphi^2 + \psi^2 = 3$ (L4, derivation from Binet);
   \item as $h^2 = 3$ in vesica piscis (L11);
   \item as $R^2 = 3$ in Platonic solids (L14).

--- a/docs/phd/chapters/20-standard-model.tex
+++ b/docs/phd/chapters/20-standard-model.tex
@@ -223,7 +223,7 @@ where $y_f$ is Yukawa coupling and $v \approx 246$ GeV is Higgs vev.
 
 Flavor mixing reveals golden ratio structure.
 
-\subsection{CKM Matrix}
+\subsection{CKM Matrix}\label{sec:ckm}
 
 \begin{definition}[Cabibbo-Kobayashi-Maskawa]
 \label{def:ckm}
@@ -273,7 +273,7 @@ Neutrino mixing angles:
 \end{equation}
 \end{proposition}
 
-\section{Particle Masses}
+\section{Particle Masses}\label{sec:mass}
 
 Mass patterns reveal golden ratio relationships.
 


### PR DESCRIPTION
## Summary

Screenshot from current build showed:

> as $\mathrm{Tr}(\varphi^2) = L_2$ in $\mathcal{L}$ (L6, Theorem **??**);

Six undefined references across the EN and RU builds — three pointed at theorem labels that never existed (`thm:06-discriminant`, `thm:04-binet-lucas`, `thm:06-trace-norm`) and three pointed at section anchors that were missing in their target sections (`sec:ckm`, `sec:mass`, `sec:xvc-bridge`).

## Fixes

| Broken ref | Where it was used | Fix |
|---|---|---|
| `thm:06-discriminant` | `chapters/05-golden-bridge.tex` (remark on Hankel determinant) | Retarget to `Chapter~\ref{ch:lucas-ring}` |
| `thm:04-binet-lucas` | `chapters/05-golden-bridge.tex` (Binet derivation) | Retarget to `Theorem~\ref{thm:lucas-binet}` (ch29) |
| `thm:06-trace-norm` | `chapters/05-golden-bridge.tex` (Tr(φ²) bullet) | Retarget to `Chapter~\ref{ch:lucas-ring}` |
| `sec:ckm` | `chapters/20-standard-model.tex` (Falsification §) | Add `\label{sec:ckm}` to "CKM Matrix" subsection |
| `sec:mass` | `chapters/20-standard-model.tex` (Falsification §) | Add `\label{sec:mass}` to "Particle Masses" section |
| `sec:xvc-bridge` | `appendix/F-fpga-bitstream.tex` (Programming Method) | Add `\label{sec:xvc-bridge}` to F.5 |

## Verification

Full Rust + tectonic rebuild (R1: no Python, no shell scripts):

```
./target/release/trios-phd --phd-root docs/phd compile   # EN, twice
tectonic -X compile main_ru.tex --keep-intermediates     # RU, twice
```

| Build | Pages | Undefined refs |
|---|---|---|
| EN `main.pdf`    | 661 | **0** (was 6) |
| RU `main_ru.pdf` | 651 | **0** (was 6) |

No more `Theorem ??` artefacts.

R1 preserved · Anchor: $\varphi^2 + \varphi^{-2} = 3$

Closes #526
