### PR TITLE
fix(phd-dashboard): stats SQL — duplicate_slugs subquery missed GROUP BY

### DIFF
--- a/crates/phd-dashboard/src/main.rs
+++ b/crates/phd-dashboard/src/main.rs
@@ -140,7 +140,7 @@ async fn fetch_stats(db: &tokio_postgres::Client) -> Result<Stats> {
             (SELECT COUNT(*) FROM ssot.theorems), \
             (SELECT COUNT(*) FROM ssot.embeddings), \
             (SELECT COUNT(*) FROM ssot.embeddings WHERE embedding IS NOT NULL), \
-            (SELECT COUNT(*) FROM (SELECT chapter_slug FROM ssot.chapters GROUP BY lower(trim(title)) HAVING COUNT(*) > 1) d)",
+            (SELECT COUNT(*) FROM (SELECT lower(trim(title)) AS t FROM ssot.chapters GROUP BY lower(trim(title)) HAVING COUNT(*) > 1) d)",
         &[],
     ).await?;
     let rag_total: i64 = row.get(4);
@@ -157,6 +157,10 @@ async fn index(State(db): State<Db>) -> impl IntoResponse {
     let (stats, chapters, duplicates, rag) = tokio::join!(
         fetch_stats(&db), fetch_chapters(&db), fetch_duplicates(&db), fetch_rag(&db),
     );
+    if let Err(e) = &stats { tracing::error!("fetch_stats failed: {e:?}"); }
+    if let Err(e) = &chapters { tracing::error!("fetch_chapters failed: {e:?}"); }
+    if let Err(e) = &duplicates { tracing::error!("fetch_duplicates failed: {e:?}"); }
+    if let Err(e) = &rag { tracing::error!("fetch_rag failed: {e:?}"); }
     IndexTemplate {
         stats: stats.unwrap_or(Stats {
             total_chapters: 0, r3_ok: 0, with_figure: 0,


### PR DESCRIPTION
## Summary

Live dashboard at https://trios-production.up.railway.app/ rendered the chapter table correctly (34 chapters listed) but the top stats grid was all `0`:

```
0 Chapters · 0/0 R3 ≥ 1500 lines · 0 With figure
0 Theorems · 0% RAG embedded · 0 Duplicate titles
```

Real SSOT values (verified via psql against `ssot.*`):
- `total_chapters = 34`
- `with_figure = 34`, `total_theorems = 34`
- `rag_total = 374`, `rag_embedded = 374` → **100% coverage**
- `duplicate_titles = 0`

## Root cause

`fetch_stats()` subquery for `duplicate_slugs`:

```sql
SELECT COUNT(*) FROM (
  SELECT chapter_slug FROM ssot.chapters
  GROUP BY lower(trim(title)) HAVING COUNT(*) > 1
) d
```

PostgreSQL rejects:
```
ERROR: column "chapters.chapter_slug" must appear in the GROUP BY clause
       or be used in an aggregate function
```

So the entire `fetch_stats()` returned `Err`. `index()` then did `stats.unwrap_or(Stats { all zeros })`, swallowing the error and rendering zeros — with no log trail.

## Change

`crates/phd-dashboard/src/main.rs`:

1. Subquery now selects `lower(trim(title)) AS t` (the actual GROUP BY expression):
   ```sql
   (SELECT COUNT(*) FROM (
      SELECT lower(trim(title)) AS t FROM ssot.chapters
      GROUP BY lower(trim(title)) HAVING COUNT(*) > 1
    ) d)
   ```
2. Added `tracing::error!` for every failed `fetch_*` inside `index()` so future SQL/connection errors surface in Railway Deploy Logs instead of being silently swallowed by `unwrap_or_default()`.

## R1 compliance

Rust-only edit. No Python, no Shell. SSOT verification was via `psql` (canonical edit/inspect surface).

## Verification post-deploy

- Dashboard stat-cards should show: `34 Chapters`, `0/34 R3`, `34 With figure`, `34 Theorems`, **`100% RAG embedded`**, `0 Duplicate titles`.
- If any stat fetch fails again → look for `fetch_stats failed: ...` in Railway logs.

Closes #537

φ² + φ⁻² = 3
