### PR TITLE
fix(ci): L-NOJS-FIX — companion workflow eliminates ghost no-js-check deadlock

### DIFF
--- a/.github/workflows/no-js-companion.yml
+++ b/.github/workflows/no-js-companion.yml
@@ -1,0 +1,38 @@
+name: No JS Companion (L-NOJS-FIX)
+
+# Why this workflow exists (queen-ratified, L-NOJS-FIX):
+#
+# Branch-protection on `main` requires a check-run named `no-js-check`.
+# The original `no-js.yml` only triggers when paths under
+# `crates/trios-ext/**` change. PRs that touch only docs / assertions /
+# proofs therefore never produce a `no-js-check` check-run, leaving
+# branch-protection in a "ghost required check" deadlock.
+#
+# This companion workflow mirrors `no-js.yml` paths-filter via
+# `paths-ignore`, runs on every other PR, and emits a job named exactly
+# `no-js-check` that always exits 0. Same context-name → branch-protection
+# satisfied in either branch (real lint runs when extension changes,
+# auto-pass companion runs otherwise). The two are mutually exclusive by
+# construction.
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'crates/trios-ext/**'
+      - '.github/workflows/no-js.yml'
+  push:
+    paths-ignore:
+      - 'crates/trios-ext/**'
+      - '.github/workflows/no-js.yml'
+
+jobs:
+  no-js-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: skip-equals-success per L-NOJS-FIX
+        run: |
+          echo "✅ no-js-check companion: PR does not touch crates/trios-ext/**"
+          echo "   The real handwritten-JS lint lives in .github/workflows/no-js.yml"
+          echo "   and runs only when extension paths change."
+          echo "   See docs/infrastructure/repo-policies.md §L-NOJS-FIX."
+          exit 0

--- a/docs/infrastructure/repo-policies.md
+++ b/docs/infrastructure/repo-policies.md
@@ -1,0 +1,86 @@
+# Repo Policies — Trinity Hive
+
+Anchor: `φ² + φ⁻² = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)
+
+This document records cross-repo settings that are not captured in code but
+are queen-ratified and must persist across operator hand-offs. Anything here
+is a contract: if a setting changes, this file must change in the same PR.
+
+## L-NOJS-FIX — companion workflow pattern (gHashTag/trios)
+
+**Problem.** Branch-protection on `main` requires a check-run named
+`no-js-check`. The original `.github/workflows/no-js.yml` only triggers when
+paths under `crates/trios-ext/**` change. PRs that touch only docs /
+assertions / proofs therefore never produce a `no-js-check` check-run, and
+branch-protection sits in a "ghost required check" deadlock — mergeable but
+blocked.
+
+**Fix (queen-ratified, R3-clean — no admin bypass, no required-check
+removal).** A companion workflow `.github/workflows/no-js-companion.yml`
+mirrors the original paths-filter via `paths-ignore` and emits a job named
+exactly `no-js-check` that always exits 0. The two workflows are mutually
+exclusive by construction:
+
+| PR scope | `no-js.yml` | `no-js-companion.yml` |
+| --- | --- | --- |
+| changes under `crates/trios-ext/**` | runs (real lint) | skipped |
+| changes anywhere else | skipped | runs (auto-pass) |
+
+Same context name → branch-protection always satisfied. Real handwritten-JS
+lint coverage on `crates/trios-ext/**` is unchanged.
+
+**Audit trail.** Original deadlock observed on
+[trios#541](https://github.com/gHashTag/trios/pull/541) (G4 — matrix-ledger
+appendix, docs-only). Queen verdict locked the sequence
+L-NOJS-FIX → L-COQ47 → L-EMBED-CRON.
+
+## trios-trainer-igla — workflow permissions (queen-ratified)
+
+The `format-algo-matrix.yml` workflow auto-opens a PR with refreshed
+`assertions/matrix_samples.jsonl`. To do so the bot needs to create PRs and
+the operator must avoid manual rebasing each cycle. The following
+repository-level settings are therefore set on
+[gHashTag/trios-trainer-igla](https://github.com/gHashTag/trios-trainer-igla):
+
+```
+default_workflow_permissions:        write
+can_approve_pull_request_reviews:    true
+```
+
+These were enabled with explicit operator confirm_action approval during
+L-MATRIX-LEDGER (G3 close, see PR #109 squash `d6f13e1`). They are scoped to
+trios-trainer-igla only — `gHashTag/trios` itself keeps the GitHub default
+(`read`).
+
+**Why this is safe.** Branch-protection on trios-trainer-igla `main` requires
+the `ci` context, `strict=true`, `required_linear_history=true`, and
+`enforce_admins=true`. Auto-merge is DISABLED at the repo level. Therefore a
+bot-opened PR cannot land without (a) the data-content `ci` job passing on
+the bot's branch and (b) a human (or another bot with review rights)
+approving the merge.
+
+**Bot identity.** The matrix-ledger bot commits as
+`trios-matrix-ledger-bot <matrix-ledger-bot@users.noreply.github.com>` to
+branches matching `auto/matrix-ledger-${GITHUB_RUN_ID}`. PR title pattern:
+`chore(matrix-ledger): refresh assertions/matrix_samples.jsonl (run ${GITHUB_RUN_ID})`.
+
+## Constitutional Enforcement (L2) — PR-body regex
+
+Branch-protection on `gHashTag/trios` `main` requires the `Constitutional
+Enforcement` context. The Laws Guard scans the PR body for:
+
+```
+(Closes|Fixes|Resolves) #[0-9]+
+```
+
+(case-insensitive). Every PR — including L-NOJS-FIX and any docs-only
+follow-up — must include such a clause referencing the tracking issue.
+
+## R3 PR-only rule (no force-push, no admin merge)
+
+`enforce_admins=true` on both `trios/main` and `trios-trainer-igla/main`. Any
+"Bypass branch-protection" intervention is a R3 violation and is forbidden
+without an explicit queen verdict recorded in this document. Stale PR
+branches must be brought up to date via `gh pr update-branch <N>` (creates a
+merge commit from main into the PR branch, R3-clean) — never via local
+force-push.


### PR DESCRIPTION
## Summary

L-NOJS-FIX — companion workflow that eliminates the ghost `no-js-check` required-check deadlock blocking docs/assertions PRs (notably [#541](https://github.com/gHashTag/trios/pull/541), G4 of L-MATRIX-LEDGER).

**Anchor:** `φ² + φ⁻² = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)

## Problem

Branch-protection on `main` requires the **`no-js-check`** context (app_id 15368, `strict=true`, `enforce_admins=true`). The original `.github/workflows/no-js.yml` triggers only on `crates/trios-ext/**` paths, so PRs that touch only `docs/`, `assertions/`, `proofs/` etc. never produce that check-run. They sit forever as `MERGEABLE/BLOCKED` — every actual check green, `no-js-check` "expected — waiting for status to be reported".

## Fix (queen-ordered)

GitHub-recommended **companion workflow pattern** (R3-clean — no admin bypass, no required-check removal, no force-push):

| PR scope | `no-js.yml` | `no-js-companion.yml` |
| --- | --- | --- |
| changes under `crates/trios-ext/**` | runs (real lint) | skipped |
| changes anywhere else | skipped | runs (auto-pass) |

`paths-ignore` filter is the exact mirror of `no-js.yml`'s `paths` filter, so the two workflows are **mutually exclusive by construction**. Same context name → branch-protection always satisfied. Real handwritten-JS lint coverage on `crates/trios-ext/**` is unchanged bit-for-bit.

This very PR is a self-test: it touches `.github/workflows/no-js.yml`'s sibling, never the original, and `docs/infrastructure/repo-policies.md`. Both paths are inside `paths-ignore` (the workflow file mirror only ignores `no-js.yml` itself, not `no-js-companion.yml`), so the companion runs and reports `no-js-check` SUCCESS.

## Side-effect doc (queen-ratified)

`docs/infrastructure/repo-policies.md` records:

- **L-NOJS-FIX** rationale and exclusivity matrix (this PR).
- **`gHashTag/trios-trainer-igla`** repository-level `default_workflow_permissions: write` + `can_approve_pull_request_reviews: true`, enabled with explicit operator confirm_action approval during L-MATRIX-LEDGER G3 (see [trios-trainer-igla#109](https://github.com/gHashTag/trios-trainer-igla/pull/109) squash `d6f13e1`).
- **R3 PR-only** rule (`enforce_admins=true` on both repos) and the `gh pr update-branch` discipline for stale branches.

## Files

- `.github/workflows/no-js-companion.yml` (new, 39 LOC) — single job `no-js-check`, `paths-ignore: ['crates/trios-ext/**', '.github/workflows/no-js.yml']`, exits 0.
- `docs/infrastructure/repo-policies.md` (new, 87 LOC).

Original `no-js.yml` is untouched.

## Acceptance

- [ ] Companion workflow runs on this PR and reports `no-js-check` SUCCESS.
- [ ] After merge, [#541](https://github.com/gHashTag/trios/pull/541) becomes mergeable without further intervention (companion will satisfy the required context on its existing branch).
- [ ] No change to behaviour on PRs that touch `crates/trios-ext/**`.

## References

- Queen verdict (three-channel dispatch): [#380 c4404063435](https://github.com/gHashTag/trios/issues/380#issuecomment-4404063435) · [#30 c4404063546](https://github.com/gHashTag/trios/issues/30#issuecomment-4404063546) · [#373 c4404063643](https://github.com/gHashTag/trios/issues/373#issuecomment-4404063643).
- Antecedent: [#542](https://github.com/gHashTag/trios/issues/542) (G4 tracker).

Sequence locked by queen: **L-NOJS-FIX → L-COQ47 → L-EMBED-CRON**.

Closes #543
