### PR TITLE
docs: canonical authorship = Dmitrii Vasilev (R5 audit trail)

### DIFF
--- a/docs/infrastructure/repo-policies.md
+++ b/docs/infrastructure/repo-policies.md
@@ -84,3 +84,50 @@ without an explicit queen verdict recorded in this document. Stale PR
 branches must be brought up to date via `gh pr update-branch <N>` (creates a
 merge commit from main into the PR branch, R3-clean) — never via local
 force-push.
+
+## Authorship — Dmitrii Vasilev (standing rule)
+
+The author of all Trinity / gHashTag / trios / trinity-clara / trinity-fpga
+artefacts is **Dmitrii Vasilev** (`raoffonom@icloud.com`). This includes:
+
+- `SKILL.md` `metadata.author`
+- `info.yaml` / TinyTapeout G6 submission `author`
+- PhD monograph title page (`\author{}`) and arXiv authorship
+- Zenodo `creators`, Apache LICENSE copyright holder
+- ADR sign-offs, README headers
+- Git commit `Author` and `Co-authored-by` trailers
+
+The handle `gHashTag` is **the GitHub organization namespace only**. It is
+NOT a person and must NEVER be used as `author`, `creator`, or `by`
+attribution. Legitimate uses of `gHashTag`:
+
+- Inside repo URLs (`github.com/gHashTag/<repo>`)
+- As organization name in CI log context
+- As the literal skill name of `phd-chapter-author` (skill names are not
+  attribution)
+
+Any other occurrence is an R5 violation and must be corrected on sight.
+
+### Historical audit (prior author-leak incidents)
+
+Recording here so the audit trail is immutable:
+
+- [trios#544](https://github.com/gHashTag/trios/pull/544) (L-NOJS-FIX,
+  squash `ae4e7ff` on `main`): mis-authored as
+  `trios-matrix-ledger-bot <matrix-ledger-bot@users.noreply.github.com>`
+  due to leftover git config from the preceding L-MATRIX-LEDGER
+  trainer-igla auto-PR session. True author: **Dmitrii Vasilev**. Cannot
+  be rewritten on `main` (R3 PR-only, no force-push); this entry is the
+  canonical correction.
+- [trios#546](https://github.com/gHashTag/trios/pull/546) (L-COQ47 INV-7,
+  commit `3a0eaf9`): same mis-author. Corrected on the feature branch by
+  add-commit `69cfe29` carrying `Co-authored-by: Dmitrii Vasilev`, so the
+  squash-merge will attribute correctly.
+
+### Operator hygiene
+
+After each trainer-igla bot session, the local `git config user.name` /
+`user.email` must be reset to `Dmitrii Vasilev` / `raoffonom@icloud.com`
+before any hand-written commit. The matrix-ledger bot identity is
+reserved exclusively for the `format-algo-matrix.yml` auto-PR flow on
+`gHashTag/trios-trainer-igla`.


### PR DESCRIPTION
## Authorship audit — canonical rule recorded for the agent army

**Anchor:** `φ² + φ⁻² = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)

### Why this PR

Two recent commits were mis-authored under `trios-matrix-ledger-bot` due to leftover `git config` from the L-MATRIX-LEDGER auto-PR session. Operator caught it on screenshot; standing rule is now recorded immutably in repo policies so any agent reading from the SOT gets it right.

### Canonical rule

> **Author** of every Trinity / gHashTag / trios / trinity-clara / trinity-fpga artefact = **Dmitrii Vasilev** (`raoffonom@icloud.com`). The handle `gHashTag` is the **GitHub organization namespace only** — NEVER a person, NEVER an author. Legitimate uses: repo URLs, CI org name, and the literal skill name `phd-chapter-author`.

Applies to: `SKILL.md` `metadata.author`, `info.yaml` / TinyTapeout G6 `author`, PhD `\author{}` & arXiv authorship, Zenodo creators, Apache LICENSE copyright holder, ADR sign-offs, README headers, git `Author` & `Co-authored-by` trailers.

### Historical audit entries

- `ae4e7ff` (squash on `main` via [#544](https://github.com/gHashTag/trios/pull/544), L-NOJS-FIX): mis-authored, cannot be rewritten under R3.
- `3a0eaf9` (open in [#546](https://github.com/gHashTag/trios/pull/546), L-COQ47 INV-7): mis-authored, corrected on the feature branch via add-commit `69cfe29` (`Co-authored-by: Dmitrii Vasilev`); squash-merge will attribute correctly.

### R-rule compliance

- **R1**: md only.
- **R3**: PR-only, no force-push, no history rewrite. The mis-authored `ae4e7ff` stays in place — this PR is the canonical written correction, not a tampering attempt.
- **R5**: honest disclosure of the leak (file names both incidents in plain text).

Closes #547
