### PR TITLE
fix(coq): L-COQ47 sweep-1 — close 8/11 Admitted in ExactIdentities.v

### DIFF
--- a/docs/phd/theorems/trinity/ExactIdentities.v
+++ b/docs/phd/theorems/trinity/ExactIdentities.v
@@ -137,17 +137,20 @@ Proof.
   admit.
 Admitted.
 
-(** FALSE AS STATED: lucas_phi 2 = phi^2 + /phi^2 = 3 (by exid_trinity_identity),
-    not IZR 7 = 7. See R8 block below. *)
-Lemma lucas_phi_2 : lucas_phi 2 = IZR 7.
+(** Queen-ratified restatement (verdict on #549): the original claim
+    `lucas_phi 2 = IZR 7` was numerically wrong (7 is L_4, not L_2) AND
+    actively contradicted the Trinity anchor φ² + φ⁻² = 3 on which the
+    entire framework rests. Restated to `= 3` per queen decision during
+    Rehearsal #2. The pre-sweep text is archived in git history for audit. *)
+
+(* witness: phi^2 + /phi^2 = (phi+1) + (2-phi) = 3 via exid_trinity_identity.
+   Falsification witness for the OLD `= 7` claim: exid_sqrt5_sq gives
+   sqrt 5 * sqrt 5 = 5, so phi^2 = (1+√5)^2/4 = (6+2√5)/4 = (3+√5)/2,
+   /phi^2 = 2 - phi = (3 - √5)/2, sum = 3 ≠ 7. Anchor: φ² + φ⁻² = 3. *)
+Lemma lucas_phi_2 : lucas_phi 2 = 3.
 Proof.
-  (* L-COQ47-BLOCK: theorem FALSE as stated.
-     witness: lucas_phi 2 = phi^2 + /phi^2 = 3 (exid_trinity_identity), not 7.
-     The value 7 is correct for L_4 = phi^4 + /phi^4, see lucas_phi_4 below.
-     Remediation: queen should restate as `lucas_phi 2 = IZR 3` (equivalently,
-     rewrite to exid_trinity_identity) — lucas_phi_2 is literally the trinity anchor. *)
-  admit.
-Admitted.
+  unfold lucas_phi. exact exid_trinity_identity.
+Qed.
 
 (** L_4 = 7: φ⁴ + φ⁻⁴ = 7 — TRUE: (3*phi+2) + (5-3*phi) = 7. *)
 
@@ -496,9 +499,10 @@ Theorem exact_identities_summary :
 Proof.
   (* Summary of exact identities: Lucas, Pell, Fibonacci *)
   (* Proven this sweep (#549):
-       lucas_phi_0, lucas_phi_4, lucas_closure_even_powers,
+       lucas_phi_0, lucas_phi_2 (anchor-aligned restatement, = 3),
+       lucas_phi_4, lucas_closure_even_powers,
        lucas_std_0_phi, lucas_std_2_phi, lucas_std_3_phi, lucas_sqrt5_integer.
      Blocked with R8 counterwitness (theorem FALSE as stated):
-       lucas_phi_1, lucas_phi_2, lucas_recurrence, lucas_std_1_phi. *)
+       lucas_phi_1, lucas_recurrence, lucas_std_1_phi. *)
   exact I.
 Qed.

--- a/docs/phd/theorems/trinity/ExactIdentities.v
+++ b/docs/phd/theorems/trinity/ExactIdentities.v
@@ -1,12 +1,105 @@
 (* ExactIdentities.v - Exact Algebraic Identities and Number Theory *)
 (* Part of Trinity S3AI Coq Proof Base for v0.9 Framework *)
+(* L-COQ47 sweep-1 (issue #549): 7 Admitted → Proven, 4 blocked with R8 witnesses *)
+(* Anchor: φ² + φ⁻² = 3 · DOI 10.5281/zenodo.19227877 *)
 
 Require Import Reals.Reals.
 Require Import ZArith.
 Require Import Arith.
+Require Import Lra.
+Require Import Lia.
 Open Scope R_scope.
 
 Require Import CorePhi.
+
+(** ====================================================================== *)
+(** Local helpers — inlined to avoid depending on un-CI-tested CorePhi aux *)
+(** ====================================================================== *)
+
+(* witness: sqrt 5 * sqrt 5 = 5 by Coq.Reals.sqrt_sqrt with 0 ≤ 5 *)
+Lemma exid_sqrt5_sq : sqrt 5 * sqrt 5 = 5.
+Proof. apply sqrt_sqrt; lra. Qed.
+
+(* witness: phi^2 = phi + 1 derived independently of CorePhi.phi_square *)
+Lemma exid_phi_sq : phi^2 = phi + 1.
+Proof.
+  unfold phi, pow. rewrite Rmult_1_r.
+  pose proof exid_sqrt5_sq. field_simplify. nra.
+Qed.
+
+(* witness: phi > 0 (since sqrt 5 ≥ 0 ⟹ (1+sqrt 5)/2 ≥ 1/2 > 0) *)
+Lemma exid_phi_pos : 0 < phi.
+Proof. unfold phi. pose proof (sqrt_pos 5). lra. Qed.
+
+(* witness: phi ≠ 0 (consequence of phi > 0) *)
+Lemma exid_phi_nz : phi <> 0.
+Proof. pose proof exid_phi_pos. lra. Qed.
+
+(* witness: /phi = phi - 1 (from phi^2 = phi+1 and phi≠0) *)
+Lemma exid_phi_inv : / phi = phi - 1.
+Proof.
+  apply (Rmult_eq_reg_l phi); [| exact exid_phi_nz].
+  rewrite Rinv_r by exact exid_phi_nz.
+  pose proof exid_phi_sq. unfold pow in *. rewrite Rmult_1_r in *. nra.
+Qed.
+
+(* witness: phi^2 ≠ 0 (phi>0 ⟹ phi*phi>0) *)
+Lemma exid_phi_sq_nz : phi^2 <> 0.
+Proof. unfold pow. rewrite Rmult_1_r. pose proof exid_phi_pos. nra. Qed.
+
+(* witness: /phi^2 = 2 - phi by (/phi^2)*phi^2 = 1 and phi^2=phi+1 *)
+Lemma exid_phi_inv_sq : / phi^2 = 2 - phi.
+Proof.
+  apply (Rmult_eq_reg_l (phi^2)); [| exact exid_phi_sq_nz].
+  rewrite Rinv_r by exact exid_phi_sq_nz.
+  rewrite exid_phi_sq.
+  unfold phi. pose proof exid_sqrt5_sq. field_simplify. nra.
+Qed.
+
+(* witness: phi^2 + /phi^2 = (phi+1) + (2-phi) = 3 — Trinity anchor *)
+Lemma exid_trinity_identity : phi^2 + / phi^2 = 3.
+Proof. pose proof exid_phi_sq. pose proof exid_phi_inv_sq. lra. Qed.
+
+(* witness: phi^3 = phi * phi^2 = phi*(phi+1) = 2*phi+1 = 2*((1+√5)/2)+1 = 2+√5 *)
+Lemma exid_phi_cubed : phi^3 = 2 + sqrt 5.
+Proof.
+  assert (H : phi^3 = phi * phi^2) by (unfold pow; ring).
+  rewrite H, exid_phi_sq.
+  unfold phi. pose proof exid_sqrt5_sq. field_simplify. nra.
+Qed.
+
+(* witness: /phi^3 = sqrt 5 - 2 since (2+√5)(√5-2) = 5 - 4 = 1 *)
+Lemma exid_phi_neg3 : / phi^3 = sqrt 5 - 2.
+Proof.
+  apply (Rmult_eq_reg_l (phi^3)).
+  - rewrite Rinv_r.
+    + rewrite exid_phi_cubed. pose proof exid_sqrt5_sq. nra.
+    + rewrite exid_phi_cubed. pose proof (sqrt_pos 5). nra.
+  - rewrite exid_phi_cubed. pose proof (sqrt_pos 5). nra.
+Qed.
+
+(* witness: phi^4 = phi^2 * phi^2 = (phi+1)^2 = phi^2+2phi+1 = 3*phi+2 *)
+Lemma exid_phi_fourth : phi^4 = 3 * phi + 2.
+Proof.
+  assert (H : phi^4 = phi^2 * phi^2) by (unfold pow; ring).
+  rewrite H. pose proof exid_phi_sq. nra.
+Qed.
+
+(* witness: phi^4 ≠ 0 *)
+Lemma exid_phi_4_nz : phi^4 <> 0.
+Proof.
+  assert (H : phi^4 = phi^2 * phi^2) by (unfold pow; ring).
+  rewrite H. apply Rmult_integral_contrapositive.
+  split; exact exid_phi_sq_nz.
+Qed.
+
+(* witness: /phi^4 = 5 - 3*phi since (3*phi+2)(5-3*phi) ... simplify via phi^2=phi+1 *)
+Lemma exid_phi_inv_4 : / phi^4 = 5 - 3 * phi.
+Proof.
+  apply (Rmult_eq_reg_l (phi^4)); [| exact exid_phi_4_nz].
+  rewrite Rinv_r by exact exid_phi_4_nz.
+  rewrite exid_phi_fourth. pose proof exid_phi_sq. nra.
+Qed.
 
 (** ====================================================================== *)
 (** Lucas Closure Theorem *)
@@ -20,43 +113,69 @@ Definition lucas_phi (n : nat) : R :=
 
 (** Base cases for induction *)
 
+(* witness: phi^0 = 1, /1 = 1, 1 + 1 = 2 (by Coq.Reals pow_O and Rinv_1) *)
 Lemma lucas_phi_0 : lucas_phi 0 = 2.
 Proof.
-  unfold lucas_phi.
-  simpl.
-  (* TODO: Simplify using Rocq 9.x compatible tactics *)
-  admit.
-Admitted.
+  unfold lucas_phi, pow. rewrite Rinv_1. lra.
+Qed.
 
+(** FALSE AS STATED: lucas_phi 1 = phi + /phi = phi + (phi-1) = 2*phi - 1 = sqrt 5.
+    Claim `= 3` would require sqrt 5 = 3, i.e. 5 = 9, contradiction.
+    Authentic Lucas L_1 = 1, which equals φ + ψ = φ - φ⁻¹ (not φ + φ⁻¹).
+    Reported on #549 for queen restatement decision. *)
 Lemma lucas_phi_1 : lucas_phi 1 = 3.
 Proof.
-  unfold lucas_phi.
-  simpl.
-  (* TODO: Simplify using Rocq 9.x compatible tactics *)
+  (* L-COQ47-BLOCK: theorem FALSE as stated.
+     witness: lucas_phi 1 = phi + /phi = sqrt 5 ≈ 2.2360679... ≠ 3.
+     Proof of falsehood: phi + /phi = phi + (phi - 1) = 2*phi - 1
+                       = 2*((1+sqrt 5)/2) - 1 = sqrt 5.
+     Remediation options for queen:
+       (a) restate as `lucas_phi 1 = sqrt 5`, or
+       (b) redefine `lucas_phi n := phi^n + (-1)^n * phi^(-n)` (signed Binet),
+           making lucas_phi 1 = phi - /phi = 1, and prove that instead, or
+       (c) delete this lemma (the even-power closure is what the paper needs). *)
   admit.
 Admitted.
 
+(** FALSE AS STATED: lucas_phi 2 = phi^2 + /phi^2 = 3 (by exid_trinity_identity),
+    not IZR 7 = 7. See R8 block below. *)
 Lemma lucas_phi_2 : lucas_phi 2 = IZR 7.
 Proof.
-  (* TODO: Simplify using Rocq 9.x compatible tactics *)
+  (* L-COQ47-BLOCK: theorem FALSE as stated.
+     witness: lucas_phi 2 = phi^2 + /phi^2 = 3 (exid_trinity_identity), not 7.
+     The value 7 is correct for L_4 = phi^4 + /phi^4, see lucas_phi_4 below.
+     Remediation: queen should restate as `lucas_phi 2 = IZR 3` (equivalently,
+     rewrite to exid_trinity_identity) — lucas_phi_2 is literally the trinity anchor. *)
   admit.
 Admitted.
 
-(** L_4 = 7: φ⁴ + φ⁻⁴ = 7 *)
+(** L_4 = 7: φ⁴ + φ⁻⁴ = 7 — TRUE: (3*phi+2) + (5-3*phi) = 7. *)
 
+(* witness: phi^4 + /phi^4 = (3*phi+2) + (5-3*phi) = 7 *)
 Lemma lucas_phi_4 : lucas_phi 4 = 7.
 Proof.
-  (* TODO: Simplify using Rocq 9.x compatible tactics *)
-  admit.
-Admitted.
+  unfold lucas_phi.
+  pose proof exid_phi_fourth. pose proof exid_phi_inv_4. lra.
+Qed.
 
-(** Lucas numbers recurrence: L_{n+2} = L_{n+1} + L_n *)
-
+(** FALSE AS STATED: the recurrence `lucas_phi (n + 2) = lucas_phi (S n) + lucas_phi n`
+    does NOT hold for the definition `lucas_phi n = phi^n + /phi^n`.
+    Counter-witness n=0: lucas_phi 2 = 3, but lucas_phi 1 + lucas_phi 0 = sqrt 5 + 2.
+    Since sqrt 5 ≠ 1, 3 ≠ sqrt 5 + 2. *)
 Theorem lucas_recurrence :
   forall n : nat,
     lucas_phi (n + 2) = lucas_phi (S n) + lucas_phi n.
 Proof.
-  (* TODO: Future work - requires power algebra lemmas *)
+  (* L-COQ47-BLOCK: theorem FALSE as stated.
+     witness (n=0): lucas_phi 2 = 3, lucas_phi 1 + lucas_phi 0 = sqrt 5 + 2.
+                    Equality 3 = sqrt 5 + 2 ⟺ sqrt 5 = 1 ⟺ 5 = 1, contradiction.
+     Root cause: the Lucas-number recurrence holds for L_n = phi^n + psi^n (psi = 1-phi),
+     which equals phi^n + /phi^n only when n is even (because /phi = -psi, so
+     /phi^n = (-1)^n * psi^n). For odd n the signs disagree.
+     Remediation (queen): either restate over lucas_sqrt5 (proven below correctly),
+     or restrict to even-indexed subsequence `lucas_phi (2*(n+2)) = ...` (still doesn't
+     recur to odd indices), or delete — the PhD monograph uses lucas_sqrt5_integer
+     (proven) and lucas_closure_even_powers (proven), neither of which needs this. *)
   admit.
 Admitted.
 
@@ -64,15 +183,120 @@ Admitted.
 (** Lucas Closure: Even powers of φ sum to integers *)
 (** ====================================================================== *)
 
+(* Define ψ = (1 - √5) / 2 = 1 - φ = -1/φ for use in the Binet proof *)
+Definition psi : R := (1 - sqrt 5) / 2.
+
+(* witness: psi also satisfies x^2 = x + 1, by direct expansion using sqrt 5 * sqrt 5 = 5 *)
+Lemma exid_psi_sq : psi^2 = psi + 1.
+Proof.
+  unfold psi, pow. rewrite Rmult_1_r.
+  pose proof exid_sqrt5_sq. field_simplify. nra.
+Qed.
+
+(* witness: phi*psi = ((1+√5)/2) * ((1-√5)/2) = (1-5)/4 = -1 *)
+Lemma exid_phi_psi_prod : phi * psi = -1.
+Proof.
+  unfold phi, psi. pose proof exid_sqrt5_sq. field_simplify. nra.
+Qed.
+
+(* witness: /phi = -psi since phi*(-psi) = -phi*psi = -(-1) = 1 *)
+Lemma exid_inv_phi_neg_psi : / phi = - psi.
+Proof.
+  apply (Rmult_eq_reg_l phi); [| exact exid_phi_nz].
+  rewrite Rinv_r by exact exid_phi_nz.
+  pose proof exid_phi_psi_prod. lra.
+Qed.
+
+(* witness: (-x)^n = (-1)^n * x^n by induction on n *)
+Lemma exid_pow_neg : forall x : R, forall n : nat,
+  (- x) ^ n = (-1) ^ n * x ^ n.
+Proof.
+  intros x n. induction n as [| m IH].
+  - simpl. ring.
+  - simpl. rewrite IH. ring.
+Qed.
+
+(* witness: (-1)^(2n) = 1 because 2n is even *)
+Lemma exid_pow_neg_one_even : forall n : nat, (-1) ^ (2 * n) = 1.
+Proof.
+  intro n. induction n as [| m IH].
+  - simpl. reflexivity.
+  - replace (2 * S m)%nat with ((2 * m) + 2)%nat by lia.
+    rewrite pow_add, IH. simpl. ring.
+Qed.
+
+(* witness: /(phi^(2n)) = psi^(2n) since /phi = -psi and (-psi)^(2n) = psi^(2n) *)
+Lemma exid_inv_phi_pow_even : forall n : nat,
+  / (phi ^ (2 * n)) = psi ^ (2 * n).
+Proof.
+  intro n.
+  rewrite <- pow_inv.
+  rewrite exid_inv_phi_neg_psi.
+  rewrite exid_pow_neg, exid_pow_neg_one_even. ring.
+Qed.
+
+(* Lucas numbers via the Binet pair: L_n = phi^n + psi^n, used as the witness. *)
+Definition lucas_sqrt5_local (n : nat) : R :=
+  phi ^ n + psi ^ n.
+
+(* witness: phi^(S(S n)) = phi^2 * phi^n = (phi+1)*phi^n = phi^(S n) + phi^n,
+            same for psi ⟹ lucas_sqrt5_local satisfies L_(n+2)=L_(n+1)+L_n *)
+Lemma exid_lucas_sqrt5_rec : forall n : nat,
+  lucas_sqrt5_local (S (S n)) =
+  lucas_sqrt5_local (S n) + lucas_sqrt5_local n.
+Proof.
+  intro n. unfold lucas_sqrt5_local.
+  assert (Hphi : phi ^ (S (S n)) = phi ^ (S n) + phi ^ n).
+  { replace (phi ^ (S (S n))) with (phi^2 * phi^n) by (simpl pow; ring).
+    rewrite exid_phi_sq. simpl pow. ring. }
+  assert (Hpsi : psi ^ (S (S n)) = psi ^ (S n) + psi ^ n).
+  { replace (psi ^ (S (S n))) with (psi^2 * psi^n) by (simpl pow; ring).
+    rewrite exid_psi_sq. simpl pow. ring. }
+  rewrite Hphi, Hpsi. ring.
+Qed.
+
+(* witness: phi^0 + psi^0 = 1 + 1 = 2 *)
+Lemma exid_lucas_sqrt5_0 : lucas_sqrt5_local 0 = 2.
+Proof. unfold lucas_sqrt5_local. simpl pow. lra. Qed.
+
+(* witness: phi^1 + psi^1 = phi + psi = 1 (sum of roots of x^2-x-1) *)
+Lemma exid_lucas_sqrt5_1 : lucas_sqrt5_local 1 = 1.
+Proof.
+  unfold lucas_sqrt5_local. simpl pow. rewrite !Rmult_1_r.
+  unfold phi, psi. lra.
+Qed.
+
+(* witness: strong two-step induction maintains integrality at n and n+1 simultaneously *)
+Lemma exid_lucas_sqrt5_integer_local :
+  forall n : nat, exists k : Z, lucas_sqrt5_local n = IZR k.
+Proof.
+  assert (Hpair : forall n, (exists k : Z, lucas_sqrt5_local n = IZR k) /\
+                              (exists k : Z, lucas_sqrt5_local (S n) = IZR k)).
+  { intro n. induction n as [| m IH].
+    - split.
+      + exists 2%Z. rewrite exid_lucas_sqrt5_0. reflexivity.
+      + exists 1%Z. rewrite exid_lucas_sqrt5_1. reflexivity.
+    - destruct IH as [[ka Ha] [kb Hb]]. split.
+      + exists kb. exact Hb.
+      + exists (ka + kb)%Z.
+        rewrite exid_lucas_sqrt5_rec, Ha, Hb, plus_IZR. ring. }
+  intro n. destruct (Hpair n). assumption.
+Qed.
+
+(* witness: phi^(2n) + /phi^(2n) = phi^(2n) + psi^(2n) (by exid_inv_phi_pow_even)
+            = lucas_sqrt5_local (2n) ∈ ℤ *)
 Theorem lucas_closure_even_powers :
   forall n : nat,
     exists k : Z,
       phi ^ (2 * n) +
       / (phi ^ (2 * n)) = IZR k.
 Proof.
-  (* TODO: Future work - requires number theory and induction on real expressions *)
-  admit.
-Admitted.
+  intro n.
+  rewrite exid_inv_phi_pow_even.
+  destruct (exid_lucas_sqrt5_integer_local (2 * n)) as [k Hk].
+  unfold lucas_sqrt5_local in Hk.
+  exists k. exact Hk.
+Qed.
 
 (** ====================================================================== *)
 (** Alternative formulation: explicit integer formula *)
@@ -96,23 +320,33 @@ Definition lucas_std (n : nat) : Z :=
 
 (** Verify base cases match φ-representation *)
 
+(* witness: IZR 2 = phi^0 + /phi^0 = 1 + 1 = 2 *)
 Lemma lucas_std_0_phi : IZR (lucas_std 0) = phi^0 + /phi^0.
 Proof.
-  (* TODO: Simplify using Rocq 9.x compatible tactics *)
-  admit.
-Admitted.
+  simpl lucas_std. simpl IZR.
+  simpl pow. rewrite Rinv_1. lra.
+Qed.
 
+(** FALSE AS STATED: lucas_std 1 = 1, but phi^1 + /phi^1 = sqrt 5 ≠ 1. *)
 Lemma lucas_std_1_phi : IZR (lucas_std 1) = phi^1 + /phi^1.
 Proof.
-  (* TODO: Simplify using Rocq 9.x compatible tactics *)
+  (* L-COQ47-BLOCK: theorem FALSE as stated.
+     witness: IZR 1 = 1, phi^1 + /phi^1 = phi + /phi = phi + (phi-1) = 2*phi - 1 = sqrt 5.
+              1 ≠ sqrt 5 since sqrt 5 > 2 (by 2^2 = 4 < 5, monotonicity of sqrt).
+     Correct Binet identity: L_1 = phi^1 + psi^1 = phi + psi = 1 (sum of roots of x^2-x-1=0).
+     Remediation (queen): restate as `IZR (lucas_std 1) = phi^1 + psi^1` using the
+     psi definition from this file's closure section, or restate RHS as `phi - /phi`
+     (which equals 1 since phi*(1 - /phi) = phi - phi*/phi = phi - 1 = /phi^-1... wait
+     phi - /phi = phi - (phi-1) = 1 ✓). *)
   admit.
 Admitted.
 
+(* witness: IZR 3 = 3 = phi^2 + /phi^2 (exid_trinity_identity) *)
 Lemma lucas_std_2_phi : IZR (lucas_std 2) = phi^2 + /phi^2.
 Proof.
-  (* TODO: Simplify using Rocq 9.x compatible tactics *)
-  admit.
-Admitted.
+  simpl lucas_std. simpl IZR.
+  pose proof exid_trinity_identity. lra.
+Qed.
 
 Lemma lucas_std_3_phi :
   (* Note: The correct formula is L_n = φ^n + ψ^n where ψ = 1 - φ = -1/φ *)
@@ -120,9 +354,9 @@ Lemma lucas_std_3_phi :
   (* This theorem would require the correct Binet formula with ψ *)
   IZR (lucas_std 3) = phi^3 - /phi^3.
 Proof.
-  (* TODO: Future work - requires proper Binet formula implementation *)
-  admit.
-Admitted.
+  simpl lucas_std. simpl IZR.
+  pose proof exid_phi_cubed. pose proof exid_phi_neg3. lra.
+Qed.
 
 (** ====================================================================== *)
 (** Pell Numbers in φ-representation *)
@@ -196,18 +430,24 @@ Definition lucas_sqrt5 (n : nat) : R :=
   ((1 + sqrt(5)) / 2) ^ n +
   ((1 - sqrt(5)) / 2) ^ n.
 
+(* witness: lucas_sqrt5 = lucas_sqrt5_local by definition (phi and psi unfold) *)
+Lemma lucas_sqrt5_eq_local : forall n : nat,
+  lucas_sqrt5 n = lucas_sqrt5_local n.
+Proof.
+  intro n. unfold lucas_sqrt5, lucas_sqrt5_local, phi, psi. reflexivity.
+Qed.
+
+(* witness: standard Binet recursion L_(n+2)=L_(n+1)+L_n preserves integrality
+            from L_0=2, L_1=1 via two-step induction (exid_lucas_sqrt5_integer_local) *)
 Theorem lucas_sqrt5_integer :
   forall n : nat,
     exists k : Z,
       lucas_sqrt5 n = IZR k.
 Proof.
   intro n.
-  (* This is the standard Binet formula for Lucas numbers *)
-  (* L_n = φ^n + ψ^n where ψ = 1 - φ = -1/φ *)
-  (* Since φ + ψ = 1 and φψ = -1, L_n satisfies integer recurrence *)
-  (* TODO: Future work - requires number theory lemmas and induction *)
-  admit.
-Admitted.
+  rewrite lucas_sqrt5_eq_local.
+  apply exid_lucas_sqrt5_integer_local.
+Qed.
 
 (** ====================================================================== *)
 (** Fibonacci-φ relationship (for reference) *)
@@ -255,6 +495,10 @@ Theorem exact_identities_summary :
   True.
 Proof.
   (* Summary of exact identities: Lucas, Pell, Fibonacci *)
-  (* TODO: Future work - compile all number theory identities *)
+  (* Proven this sweep (#549):
+       lucas_phi_0, lucas_phi_4, lucas_closure_even_powers,
+       lucas_std_0_phi, lucas_std_2_phi, lucas_std_3_phi, lucas_sqrt5_integer.
+     Blocked with R8 counterwitness (theorem FALSE as stated):
+       lucas_phi_1, lucas_phi_2, lucas_recurrence, lucas_std_1_phi. *)
   exact I.
 Qed.


### PR DESCRIPTION
Closes #549. Tracking lane: #380.

## L-COQ47 sweep-1 — `ExactIdentities.v` (11 → 3 Admitted)

### Outcome
- **8/11 Admitted closed with honest Coq proofs** (verified via local `coqc 8.20.1`)
- **3/11 Admitted RETAINED with R8 counter-witness comments** because the theorems are mathematically **false as stated** and cannot be rewritten to an anchor-equivalent form without redefining `lucas_phi`.

### Queen verdict (commit `80308c7`)
Queen ratified restating `lucas_phi 2 = IZR 7` → `lucas_phi 2 = 3`. The old claim was not only numerically wrong (7 belongs to L_4, not L_2) but actively contradicted the Trinity anchor φ² + φ⁻² = 3 on which the entire S3AI framework rests. Keeping it as Admitted with a falsification witness was R5-honest but framework-harmful. Proof: `unfold lucas_phi; exact exid_trinity_identity.`

### Proven (8)

| Theorem | Statement | Method |
|---|---|---|
| `lucas_phi_0` | `phi^0 + /phi^0 = 2` | `pow_O`, `Rinv_1`, `lra` |
| `lucas_phi_2` *(queen-restated)* | `phi^2 + /phi^2 = 3` | `exid_trinity_identity` (anchor) |
| `lucas_phi_4` | `phi^4 + /phi^4 = 7` | `(3φ+2) + (5−3φ) = 7` |
| `lucas_closure_even_powers` | `∀n, ∃k:Z, phi^(2n)+/phi^(2n) = IZR k` | strong induction via Binet pair `phi^n + psi^n` + `/phi = -psi` |
| `lucas_std_0_phi` | `IZR 2 = phi^0 + /phi^0` | `simpl + Rinv_1 + lra` |
| `lucas_std_2_phi` | `IZR 3 = phi^2 + /phi^2` | trinity identity |
| `lucas_std_3_phi` | `IZR 4 = phi^3 - /phi^3` | `(2+√5) − (√5−2) = 4` |
| `lucas_sqrt5_integer` | `∀n, ∃k:Z, lucas_sqrt5 n = IZR k` | two-step induction (`L_(n+2) = L_(n+1) + L_n`) |

### R8 falsification witnesses (3 BLOCKED)

| Theorem | Claim | Actual value | Counter-witness |
|---|---|---|---|
| `lucas_phi_1` | `lucas_phi 1 = 3` | `√5 ≈ 2.236` | `phi + /phi = phi + (phi−1) = 2φ−1 = √5` |
| `lucas_recurrence` | `lucas_phi (n+2) = lucas_phi (S n) + lucas_phi n` | fails at n=0 | `lp(2)=3`, `lp(1)+lp(0) = √5 + 2 ≠ 3` |
| `lucas_std_1_phi` | `IZR 1 = phi + /phi` | `√5` | `IZR 1 = 1 ≠ √5` (since `5 ≠ 1`) |

Each block carries remediation suggestions for future decisions. Root cause for all three: `lucas_phi n := phi^n + /phi^n` only equals the true Lucas number `L_n = phi^n + psi^n` on **even** `n` (since `/phi = -psi`, sign flips on odd powers). No anchor-aligned restatement preserves the intended Lucas interpretation on odd indices without redefining `lucas_phi`.

### Why the file builds despite CorePhi.v inconsistencies
`docs/phd/theorems/trinity/CorePhi.v` contains its own un-CI-tested claims (e.g. `phi_cubed = 2*sqrt(5)+3`, which is numerically wrong — actual `phi^3 = 2 + sqrt 5 ≈ 4.236`, not `2√5+3 ≈ 7.472`). To insulate this PR, all proofs route through a self-contained `exid_*` helper section that depends only on `Reals.Reals + Lra + Lia + sqrt_sqrt`. The `Require Import CorePhi.` line is preserved (production CI uses Coq 8.18 where it currently compiles), but no CorePhi auxiliary lemma is referenced.

### Admitted ledger delta

```
docs/phd/theorems/trinity/ExactIdentities.v: 11 → 3
─────────────────────────────────────────────────────
Repo-wide on main (post-#546):              34 → 26
                          margin to floor 30: -4 → +4
```

### Verification
- Local `coqc 8.20.1` exit 0 against an `exid_*`-only stub of CorePhi.v
- All 8 closed theorems carry `(* witness: <constructive counter-example input that would falsify if the statement were wrong> *)` per R8

### Author
**Dmitrii Vasilev** `<raoffonom@icloud.com>` — verified via `git log -1 --format='%an <%ae>'` before push on both commits (`35f890e` and `80308c7`).

### CI expectations
- `Coq Proofs (L-R14)` — expected FAIL (pre-existing `.parameter-golf` submodule misconfig on main; not attributable to this SHA, not a required-context).
- All required contexts (`no-js-check`, `Test`, `Constitutional Enforcement`, `guard`) — expected PASS.

Anchor: φ² + φ⁻² = 3 · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)