### PR TITLE
fix(coq): L-COQ47/exid-cleanup — DELETE 3 R8-blocked per queen ruling

### DIFF
--- a/docs/phd/theorems/trinity/ExactIdentities.v
+++ b/docs/phd/theorems/trinity/ExactIdentities.v
@@ -119,23 +119,14 @@ Proof.
   unfold lucas_phi, pow. rewrite Rinv_1. lra.
 Qed.
 
-(** FALSE AS STATED: lucas_phi 1 = phi + /phi = phi + (phi-1) = 2*phi - 1 = sqrt 5.
-    Claim `= 3` would require sqrt 5 = 3, i.e. 5 = 9, contradiction.
-    Authentic Lucas L_1 = 1, which equals φ + ψ = φ - φ⁻¹ (not φ + φ⁻¹).
-    Reported on #549 for queen restatement decision. *)
-Lemma lucas_phi_1 : lucas_phi 1 = 3.
-Proof.
-  (* L-COQ47-BLOCK: theorem FALSE as stated.
-     witness: lucas_phi 1 = phi + /phi = sqrt 5 ≈ 2.2360679... ≠ 3.
-     Proof of falsehood: phi + /phi = phi + (phi - 1) = 2*phi - 1
-                       = 2*((1+sqrt 5)/2) - 1 = sqrt 5.
-     Remediation options for queen:
-       (a) restate as `lucas_phi 1 = sqrt 5`, or
-       (b) redefine `lucas_phi n := phi^n + (-1)^n * phi^(-n)` (signed Binet),
-           making lucas_phi 1 = phi - /phi = 1, and prove that instead, or
-       (c) delete this lemma (the even-power closure is what the paper needs). *)
-  admit.
-Admitted.
+(** DELETED per queen ruling on #549 (issuecomment-4405990351): the claim
+    `lucas_phi 1 = 3` is FALSE AS STATED (actual value = sqrt 5, because
+    /phi = -psi inverts the sign on odd powers). No anchor-aligned restatement
+    preserves the intended Lucas interpretation without redefining `lucas_phi`
+    (see R8 witness in git history commit 2929dbdb for the full falsification).
+    The PhD monograph relies on `lucas_sqrt5_integer` and `lucas_closure_even_powers`
+    (both Qed in this file), neither of which references the odd-index lemmas.
+    R5 §honest-status: REMOVE > paper over with Admitted. *)
 
 (** Queen-ratified restatement (verdict on #549): the original claim
     `lucas_phi 2 = IZR 7` was numerically wrong (7 is L_4, not L_2) AND
@@ -161,26 +152,14 @@ Proof.
   pose proof exid_phi_fourth. pose proof exid_phi_inv_4. lra.
 Qed.
 
-(** FALSE AS STATED: the recurrence `lucas_phi (n + 2) = lucas_phi (S n) + lucas_phi n`
-    does NOT hold for the definition `lucas_phi n = phi^n + /phi^n`.
-    Counter-witness n=0: lucas_phi 2 = 3, but lucas_phi 1 + lucas_phi 0 = sqrt 5 + 2.
-    Since sqrt 5 ≠ 1, 3 ≠ sqrt 5 + 2. *)
-Theorem lucas_recurrence :
-  forall n : nat,
-    lucas_phi (n + 2) = lucas_phi (S n) + lucas_phi n.
-Proof.
-  (* L-COQ47-BLOCK: theorem FALSE as stated.
-     witness (n=0): lucas_phi 2 = 3, lucas_phi 1 + lucas_phi 0 = sqrt 5 + 2.
-                    Equality 3 = sqrt 5 + 2 ⟺ sqrt 5 = 1 ⟺ 5 = 1, contradiction.
-     Root cause: the Lucas-number recurrence holds for L_n = phi^n + psi^n (psi = 1-phi),
-     which equals phi^n + /phi^n only when n is even (because /phi = -psi, so
-     /phi^n = (-1)^n * psi^n). For odd n the signs disagree.
-     Remediation (queen): either restate over lucas_sqrt5 (proven below correctly),
-     or restrict to even-indexed subsequence `lucas_phi (2*(n+2)) = ...` (still doesn't
-     recur to odd indices), or delete — the PhD monograph uses lucas_sqrt5_integer
-     (proven) and lucas_closure_even_powers (proven), neither of which needs this. *)
-  admit.
-Admitted.
+(** DELETED per queen ruling on #549 (issuecomment-4405990351): the recurrence
+    `lucas_phi (n + 2) = lucas_phi (S n) + lucas_phi n` is FALSE AS STATED
+    (counter-witness n=0: lp(2)=3, lp(1)+lp(0)=sqrt 5 + 2, and 3 ≠ sqrt 5 + 2).
+    The Lucas recurrence holds for L_n = phi^n + psi^n, which equals
+    `lucas_phi n = phi^n + /phi^n` only on EVEN n (/phi = -psi inverts sign on
+    odd powers). Even-index closure is already proven by `lucas_closure_even_powers`;
+    general-index recurrence requires redefining `lucas_phi` via signed Binet,
+    which is structural change out of scope. R8 witness preserved in commit 2929dbdb. *)
 
 (** ====================================================================== *)
 (** Lucas Closure: Even powers of φ sum to integers *)
@@ -330,19 +309,14 @@ Proof.
   simpl pow. rewrite Rinv_1. lra.
 Qed.
 
-(** FALSE AS STATED: lucas_std 1 = 1, but phi^1 + /phi^1 = sqrt 5 ≠ 1. *)
-Lemma lucas_std_1_phi : IZR (lucas_std 1) = phi^1 + /phi^1.
-Proof.
-  (* L-COQ47-BLOCK: theorem FALSE as stated.
-     witness: IZR 1 = 1, phi^1 + /phi^1 = phi + /phi = phi + (phi-1) = 2*phi - 1 = sqrt 5.
-              1 ≠ sqrt 5 since sqrt 5 > 2 (by 2^2 = 4 < 5, monotonicity of sqrt).
-     Correct Binet identity: L_1 = phi^1 + psi^1 = phi + psi = 1 (sum of roots of x^2-x-1=0).
-     Remediation (queen): restate as `IZR (lucas_std 1) = phi^1 + psi^1` using the
-     psi definition from this file's closure section, or restate RHS as `phi - /phi`
-     (which equals 1 since phi*(1 - /phi) = phi - phi*/phi = phi - 1 = /phi^-1... wait
-     phi - /phi = phi - (phi-1) = 1 ✓). *)
-  admit.
-Admitted.
+(** DELETED per queen ruling on #549 (issuecomment-4405990351): the claim
+    `IZR (lucas_std 1) = phi^1 + /phi^1` is FALSE AS STATED (LHS = 1, RHS = sqrt 5).
+    The correct Binet identity uses psi: `L_1 = phi + psi = 1`, which is NOT what
+    this lemma stated. Restating would introduce a parallel-definition trap (two
+    incompatible lucas_* interpretations). Monograph chapters cite only the
+    even-index lemmas (lucas_std_0_phi, lucas_std_2_phi) and lucas_std_3_phi,
+    which uses the correct `phi^3 - /phi^3` signed form. R8 witness preserved in
+    commit 2929dbdb. *)
 
 (* witness: IZR 3 = 3 = phi^2 + /phi^2 (exid_trinity_identity) *)
 Lemma lucas_std_2_phi : IZR (lucas_std 2) = phi^2 + /phi^2.
@@ -502,7 +476,10 @@ Proof.
        lucas_phi_0, lucas_phi_2 (anchor-aligned restatement, = 3),
        lucas_phi_4, lucas_closure_even_powers,
        lucas_std_0_phi, lucas_std_2_phi, lucas_std_3_phi, lucas_sqrt5_integer.
-     Blocked with R8 counterwitness (theorem FALSE as stated):
-       lucas_phi_1, lucas_recurrence, lucas_std_1_phi. *)
+     Deleted per queen ruling #549 (cleanup sweep, commit TBD):
+       lucas_phi_1 (was claiming `= 3`, actual = sqrt 5),
+       lucas_recurrence (fails at n=0 on odd-index sign mismatch),
+       lucas_std_1_phi (LHS = 1, RHS = sqrt 5).
+     All three R8 witnesses preserved in git history (PR #550 merge 2929dbdb). *)
   exact I.
 Qed.


### PR DESCRIPTION
Closes #549. Tracking lane: #380.

## L-COQ47/exid-cleanup — DELETE 3 R8-blocked per queen ruling

Queen ratified on [#549 issuecomment-4405990351](https://github.com/gHashTag/trios/issues/549#issuecomment-4405990351) **DELETE over restate** for the three theorems that were left as R8-blocked Admitted in sweep-1 (PR #550) because their claims are FALSE AS STATED.

### Deleted (3)

| Theorem | Claim | Actual value | Witness |
|---|---|---|---|
| `lucas_phi_1` | `lucas_phi 1 = 3` | `sqrt 5 ≈ 2.236` | `phi + /phi = phi + (phi−1) = 2φ−1 = sqrt 5`, and `sqrt 5 = 3` iff `5 = 9`, contradiction |
| `lucas_recurrence` | `lucas_phi (n+2) = lucas_phi (S n) + lucas_phi n, ∀n` | fails at n=0 | `lp(2)=3, lp(1)+lp(0)=sqrt 5 + 2`, and `3 = sqrt 5 + 2` iff `sqrt 5 = 1` iff `5 = 1`, contradiction |
| `lucas_std_1_phi` | `IZR (lucas_std 1) = phi^1 + /phi^1` | LHS=1, RHS=`sqrt 5` | `IZR 1 = 1`, `phi + /phi = sqrt 5 > 2`, so `1 ≠ sqrt 5` |

All three are replaced with a `(** DELETED per queen ruling on #549 ...)` block that records the falsehood, the witness numerics, the decision rationale, and a git reference to the preserved R8 witness in commit `2929dbdb` (sweep-1 merge).

### Rationale for DELETE over restate (per queen)

1. **Monograph doesn't reference them**: the PhD chapters cite only `lucas_sqrt5_integer` and `lucas_closure_even_powers` (both Qed after sweep-1), plus `lucas_std_0_phi`, `lucas_std_2_phi`, `lucas_std_3_phi` (all Qed with correct signed form). None of the three deleted odd-index lemmas are referenced.
2. **Restate would create a parallel-definition trap**: switching to `lucas_sqrt5_n = phi^n + psi^n` in one place while keeping `lucas_phi n = phi^n + /phi^n` in another creates two incompatible `lucas_*` families in one file.
3. **R5 §honest-status**: REMOVE > paper-over with Admitted when an R8 witness cannot be converted into an anchor-aligned TRUE statement without redefining the underlying function. Signed-Binet `lucas_phi n := phi^n + (-1)^n * phi^(-n)` is a structural change, out of scope for this sweep.
4. **Audit trail is permanent**: the full R8 witnesses (including numeric counter-examples and remediation menus) are preserved in git history via PR #550 merge commit `2929dbdb`.

### Final theorem inventory in `ExactIdentities.v`

**Proven (43) — all Qed.** Key Lucas/Fibonacci/Pell identities:
- `lucas_phi_0 = 2`, `lucas_phi_2 = 3` (queen-restated, anchor-aligned), `lucas_phi_4 = 7`
- `lucas_closure_even_powers : ∀n, ∃k:Z, phi^(2n)+/phi^(2n) = IZR k` (strong induction via Binet pair)
- `lucas_std_0_phi`, `lucas_std_2_phi`, `lucas_std_3_phi` (correct signed form `phi^3 - /phi^3`)
- `lucas_sqrt5_integer` (two-step induction over `phi^n + psi^n`)
- 34 `exid_*` self-contained helpers (Reals + Lra + Lia + sqrt_sqrt only)

**Admitted: 0.**

### Admitted ledger delta

```
docs/phd/theorems/trinity/ExactIdentities.v: 3 → 0
Repo-wide on main (post sweep-1 26):          26 → 23
                      margin to floor 30:     +4 → +7
```

### Verification

- Local `coqc 8.20.1` exit 0 against an `exid_*`-only stub of `CorePhi.v` (same isolation pattern as sweep-1).
- Zero cross-references to deleted names: verified via `grep -rn 'lucas_phi_1\|lucas_recurrence\|lucas_std_1_phi' --include='*.v' --include='*.tex' --include='*.md' .` (only matches are inside the DELETED-per-queen comments and the updated `exact_identities_summary` block).

### Author

**Dmitrii Vasilev** `<raoffonom@icloud.com>` — verified via `git log -1 --format='%an <%ae>'` before push on commit `dd1c88d`.

### CI expectations

- `Coq Proofs (L-R14)` — expected FAIL (pre-existing `.parameter-golf` submodule misconfig on main; not attributable to this SHA, not a required-context).
- All required contexts (`no-js-check`, `Test`, `Constitutional Enforcement`, `guard`) — expected PASS.

Anchor: φ² + φ⁻² = 3 · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)
