### PR TITLE
docs(phd): L-KAT-BIB — KART + KAN bibliography (closes #573)

### DIFF
--- a/docs/phd/bibliography.bib
+++ b/docs/phd/bibliography.bib
@@ -2322,3 +2322,125 @@
                companion to the dimensional analysis and symmetry methods
                chapters.}
 }
+
+% -------------------------------------------------------------------
+% 16. Kolmogorov–Arnold representation theorem (KART) and KAN networks
+%     (issue #573 / epic #572 — KART is structural inspiration only;
+%     primary theoretical foundation is finite-field expressivity)
+% -------------------------------------------------------------------
+
+@article{kolmogorov_kar_1957,
+  author    = {Kolmogorov, Andrey N.},
+  title     = {On the Representation of Continuous Functions of Many Variables
+               by Superposition of Continuous Functions of One Variable
+               and Addition},
+  journal   = {Doklady Akademii Nauk SSSR},
+  volume    = {114},
+  number    = {5},
+  year      = {1957},
+  pages     = {953--956},
+  language  = {Russian},
+  note      = {English translation: American Mathematical Society Translation,
+               series 2, vol.\ 28, pp.\ 55--59 (1963).
+               Foundational statement of the Kolmogorov–Arnold representation
+               theorem; structural inspiration for KAN architectures.
+               MathNet: http://www.mathnet.ru/eng/dan22050.}
+}
+
+@article{arnold_kar_1957,
+  author    = {Arnold, Vladimir I.},
+  title     = {On Functions of Three Variables},
+  journal   = {Doklady Akademii Nauk SSSR},
+  volume    = {114},
+  number    = {4},
+  year      = {1957},
+  pages     = {679--681},
+  language  = {Russian},
+  note      = {Companion to \cite{kolmogorov_kar_1957}; resolves Hilbert's
+               13th problem in the continuous case by representing
+               continuous functions of three variables as superpositions
+               of continuous functions of two variables. Together with
+               Kolmogorov (1957) constitutes the Kolmogorov–Arnold
+               representation theorem (KART).}
+}
+
+@misc{liu_kan_2024,
+  author    = {Liu, Ziming and Wang, Yixuan and Vaidya, Sachin and
+               Ruehle, Fabian and Halverson, James and
+               Solja{\v{c}}i{\'c}, Marin and Hou, Thomas Y. and
+               Tegmark, Max},
+  title     = {{KAN}: {Kolmogorov}--{Arnold} Networks},
+  year      = {2024},
+  eprint    = {2404.19756},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.LG},
+  doi       = {10.48550/arXiv.2404.19756},
+  url       = {https://arxiv.org/abs/2404.19756},
+  note      = {Original KAN preprint. Replaces fixed activations on
+               nodes with learnable univariate splines on edges,
+               motivated by the Kolmogorov–Arnold representation
+               theorem (KART). Foundational reference for the KAN
+               architecture family.}
+}
+
+@inproceedings{liu_kan2_2025,
+  author    = {Liu, Ziming and Wang, Yixuan and Vaidya, Sachin and
+               Ruehle, Fabian and Halverson, James and
+               Solja{\v{c}}i{\'c}, Marin and Hou, Thomas Y. and
+               Tegmark, Max},
+  title     = {{KAN}: {Kolmogorov}--{Arnold} Networks},
+  booktitle = {The Thirteenth International Conference on Learning
+               Representations (ICLR 2025), Oral},
+  year      = {2025},
+  url       = {https://openreview.net/forum?id=Ozo7qJ5vZi},
+  note      = {Peer-reviewed ICLR 2025 Oral version of the KAN
+               architecture (cf. \cite{liu_kan_2024}). Submission 5796.
+               Cited as ``KAN 2.0'' in the trios chapter draft.}
+}
+
+@misc{finite_field_expressivity_2025,
+  author    = {Zubkov, Maksym and Wu, Carol and Yang, Shiwei and
+               Mody, Param and Chen, Yifei},
+  title     = {Expressivity of Shallow Neural Networks Over Finite
+               Fields},
+  year      = {2025},
+  url       = {https://openreview.net/forum?id=tfGuvCp50e},
+  note      = {OpenReview submission tfGuvCp50e (ICLR 2026 submission
+               cycle, original 2025 draft). Studies expressivity of
+               shallow polynomial neural networks with monomial
+               activations over finite fields, defining the neuromanifold
+               and linking expressivity to counting rational points
+               (Weil conjectures). PRIMARY theoretical foundation for
+               the IGLA / GF(16) framework per epic #572 erratum.}
+}
+
+@inproceedings{finite_group_vsa_2022,
+  author    = {Yu, Tao and Zhang, Yichi and Zhang, Zhiru and
+               De Sa, Christopher},
+  title     = {Understanding Hyperdimensional Computing for Parallel
+               Single-Pass Learning},
+  booktitle = {Advances in Neural Information Processing Systems 35
+               (NeurIPS 2022)},
+  year      = {2022},
+  url       = {https://proceedings.neurips.cc/paper_files/paper/2022/hash/080be5eb7e887319ff30c792c2cbc28c-Abstract-Conference.html},
+  note      = {Closest prior art to the GF(16) IGLA construction:
+               analyzes hyperdimensional / vector-symbolic computing
+               over finite groups (\(\mathbb{Z}/16\mathbb{Z}\) family)
+               vs.\ the field GF(16) used here. NeurIPS 2022 main
+               conference track.}
+}
+
+@misc{kantize_2026,
+  author    = {Errabii, Sohaib and Sentieys, Olivier and Traiola, Marcello},
+  title     = {{KANtize}: Exploring Low-bit Quantization of
+               {Kolmogorov}--{Arnold} Networks for Efficient Inference},
+  year      = {2026},
+  eprint    = {2603.17230},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.AR},
+  doi       = {10.48550/arXiv.2603.17230},
+  url       = {https://arxiv.org/abs/2603.17230},
+  note      = {Closest prior art combining KAN with quantization for
+               efficient inference; complements the GF(16)-quantized
+               IGLA construction in this thesis.}
+}


### PR DESCRIPTION
## L-KAT-BIB merge-blocker gate

Closes #573. Parent epic #572.

7 bibliography entries added to `docs/phd/bibliography.bib` enabling all downstream L-KAT chapter lanes (#574, #575, #576, #577, #578) to compile with proper citations.

Per erratum on #573: PRIMARY theoretical foundation = finite-field expressivity (ICLR 2025 cycle, OpenReview `tfGuvCp50e`). KART = structural inspiration only.

### Entries added (alphabetical by key)

| Key | Source | Role |
|-----|--------|------|
| `arnold_kar_1957` | Doklady AN SSSR 114(4):679–681 (1957) | KART foundational (structural) |
| `finite_field_expressivity_2025` | OpenReview `tfGuvCp50e` (Zubkov, Wu, Yang, Mody, Chen) | **PRIMARY theoretical foundation** |
| `finite_group_vsa_2022` | NeurIPS 2022, Yu, Zhang, Zhang, De Sa — *Understanding Hyperdimensional Computing for Parallel Single-Pass Learning* | Closest prior art (Z/16Z vs GF(16)) |
| `kantize_2026` | arXiv:2603.17230, Errabii, Sentieys, Traiola — *KANtize* | Closest KAN+quantization prior |
| `kolmogorov_kar_1957` | Doklady AN SSSR 114(5):953–956 (1957) | KART foundational (structural) |
| `liu_kan_2024` | arXiv:2404.19756, Liu et al. | KAN architecture (preprint) |
| `liu_kan2_2025` | ICLR 2025 Oral, Liu et al. (OpenReview `Ozo7qJ5vZi`) | KAN architecture (peer-reviewed) |

### Notes on citation lookup

- All authors and titles verified against arXiv API and OpenReview API v2 records.
- `finite_field_expressivity_2025`: the OpenReview record for `tfGuvCp50e` carries venue field `ICLR.cc/2026/Conference/Rejected_Submission`; per the erratum on #573 the entry is keyed and dated against the original 2025 ICLR submission cycle as instructed. The `note` field documents the OpenReview ID for traceability.
- `kantize_2026` arXiv ID `2603.17230` placed in March 2026 (per arXiv submission date).

### Anchor

phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877

### Verification

`bash docs/phd/scripts/verify-bibliography.run docs/phd/bibliography.bib` → 212 entries, status VALID (was 205 before this PR; +7 entries, no missing keys).

Tectonic compile not run locally (binary not available in this environment); CI will catch any LaTeX-side issues.