### PR TITLE
L-DDL-SIDECAR: bpb_samples migration + postrun_sidecar self-bootstrap

### DIFF
--- a/bin/postrun_sidecar/README.md
+++ b/bin/postrun_sidecar/README.md
@@ -1,0 +1,53 @@
+# trios-postrun-sidecar
+
+Anchor: `phi^2 + phi^-2 = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)
+
+## Purpose
+
+Ingest BPB rows produced by tier runners (`trios-mr-tier{1,2a,2b,3}-runner`) into
+`ssot.bpb_samples` on the Railway-hosted postgres SSOT
+(`phd-postgres-ssot`). One row per `(cell_id, seed, sha_pin)` triple,
+deduplicated by the table's UNIQUE constraint. The sidecar is the single
+service authorised to write to `ssot.bpb_samples`; runners never write
+directly.
+
+## Self-bootstrap
+
+`migrate.ts` runs first on every sidecar boot. It reads
+`migrations/2026-05-09_bpb_samples.sql` and applies it against the
+configured database. The migration is idempotent (every statement is
+`CREATE … IF NOT EXISTS`), so re-running is always safe.
+
+## Environment variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `RAILWAY_POSTGRES_URL` | — (required) | Primary postgres URL; points to `phd-postgres-ssot`. |
+| `NEON_DATABASE_URL` | — | Legacy fallback (sunset pending L-NEON-RENAME). Used only if `RAILWAY_POSTGRES_URL` is unset. |
+| `POLL_INTERVAL_S` | `60` | Seconds between polling iterations. |
+
+## Deploy
+
+Via the TRI MCP tool:
+
+```
+railway_service_deploy({
+  name: "trios-postrun-sidecar",
+  image: "ghcr.io/ghashtag/trios-trainer-igla:latest",
+  env: {
+    RAILWAY_POSTGRES_URL: "${{phd-postgres-ssot.DATABASE_URL}}",
+    POLL_INTERVAL_S: "60",
+    ENTRYPOINT_OVERRIDE: "node bin/postrun_sidecar/migrate.ts && node bin/postrun_sidecar/index.js"
+  },
+  project: "e4fe33bb-3b09-4842-9782-7d2dea1abc9b"
+})
+```
+
+The `ENTRYPOINT_OVERRIDE` chains `migrate.ts` (synchronous, exits 0 on
+success) and the long-running poll loop (`index.js`, not in scope for this
+PR). Failure of `migrate.ts` aborts the chain so the sidecar never polls
+against an un-migrated schema.
+
+## Anchor
+
+`phi^2 + phi^-2 = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)

--- a/bin/postrun_sidecar/migrate.ts
+++ b/bin/postrun_sidecar/migrate.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * bin/postrun_sidecar/migrate.ts — self-bootstrap schema for the
+ * `trios-postrun-sidecar` Railway service.
+ *
+ * Reads `migrations/2026-05-09_bpb_samples.sql` and executes it against the
+ * postgres SSOT (Railway service `phd-postgres-ssot`). Idempotent — every
+ * statement in the SQL file is `CREATE … IF NOT EXISTS`, so re-running on
+ * each sidecar boot is safe.
+ *
+ * Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877.
+ *
+ * L1 compliance: TypeScript only, no `.sh`. Run via `npx tsx`.
+ *
+ * Required env (one of):
+ *   RAILWAY_POSTGRES_URL   primary, points to phd-postgres-ssot
+ *   NEON_DATABASE_URL      legacy fallback (sunset pending L-NEON-RENAME)
+ *
+ * Usage:
+ *   npx tsx bin/postrun_sidecar/migrate.ts
+ *
+ * Exit codes:
+ *   0  schema applied (or already present)
+ *   1  postgres connection / query failure
+ *   2  required env vars not set
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Client } from "pg";
+
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const MIGRATION_PATH = resolve(
+  REPO_ROOT,
+  "migrations/2026-05-09_bpb_samples.sql",
+);
+const ANCHOR = "phi^2 + phi^-2 = 3";
+const DOI = "10.5281/zenodo.19227877";
+
+function resolveDbUrl(): string {
+  const primary = process.env.RAILWAY_POSTGRES_URL;
+  const legacy = process.env.NEON_DATABASE_URL;
+  const url = (primary && primary.length > 0 ? primary : legacy) || "";
+  if (!url) {
+    process.stderr.write(
+      "[migrate] RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set\n",
+    );
+    process.exit(2);
+  }
+  return url;
+}
+
+async function main(): Promise<number> {
+  const dbUrl = resolveDbUrl();
+  process.stdout.write(
+    `[migrate] anchor=${ANCHOR} doi=${DOI} migration=${MIGRATION_PATH}\n`,
+  );
+
+  let sql: string;
+  try {
+    sql = readFileSync(MIGRATION_PATH, "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `[migrate] failed to read migration file: ${(err as Error).message}\n`,
+    );
+    return 1;
+  }
+
+  const client = new Client({ connectionString: dbUrl });
+  try {
+    await client.connect();
+    // The whole .sql file is sent as a single multi-statement query.
+    // Every statement is CREATE … IF NOT EXISTS, so this is idempotent.
+    await client.query(sql);
+    process.stdout.write("[migrate] bpb_samples ready\n");
+    return 0;
+  } catch (err) {
+    process.stderr.write(
+      `[migrate] postgres error: ${(err as Error).message}\n`,
+    );
+    return 1;
+  } finally {
+    await client.end().catch(() => {
+      /* ignore close errors */
+    });
+  }
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    process.stderr.write(
+      `[migrate] FATAL: ${(err as Error).stack || err}\n`,
+    );
+    process.exit(1);
+  });

--- a/migrations/2026-05-09_bpb_samples.sql
+++ b/migrations/2026-05-09_bpb_samples.sql
@@ -1,0 +1,21 @@
+-- bpb_samples: per-cell BPB result rows produced by tier runners
+-- Single source of truth for matrix #446 coverage progress.
+-- Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877
+CREATE SCHEMA IF NOT EXISTS ssot;
+
+CREATE TABLE IF NOT EXISTS ssot.bpb_samples (
+    id              BIGSERIAL PRIMARY KEY,
+    cell_id         INTEGER NOT NULL,
+    tier            TEXT NOT NULL,
+    seed            INTEGER NOT NULL,
+    bpb             DOUBLE PRECISION NOT NULL,
+    steps           INTEGER NOT NULL,
+    sha_pin         TEXT NOT NULL,
+    runner_service  TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (cell_id, seed, sha_pin)
+);
+
+CREATE INDEX IF NOT EXISTS bpb_samples_cell_idx ON ssot.bpb_samples (cell_id);
+CREATE INDEX IF NOT EXISTS bpb_samples_tier_idx ON ssot.bpb_samples (tier);
+CREATE INDEX IF NOT EXISTS bpb_samples_created_idx ON ssot.bpb_samples (created_at DESC);


### PR DESCRIPTION
## Summary

Two-lane plan-only delivery for the matrix #446 ingestion path:

- **Lane 1 — DDL migration**: [`migrations/2026-05-09_bpb_samples.sql`](../blob/feat/l-ddl-sidecar/migrations/2026-05-09_bpb_samples.sql) — creates `ssot.bpb_samples` (one row per `(cell_id, seed, sha_pin)` triple) plus three indexes. All statements `IF NOT EXISTS` (idempotent).
- **Lane 2 — sidecar self-bootstrap**: [`bin/postrun_sidecar/migrate.ts`](../blob/feat/l-ddl-sidecar/bin/postrun_sidecar/migrate.ts) — reads the migration file, connects via `pg`, executes it, logs `[migrate] bpb_samples ready`. Resolves DB URL from `RAILWAY_POSTGRES_URL` with `NEON_DATABASE_URL` legacy fallback (per L-NEON-RENAME). Designed to run before the polling loop on every sidecar boot.
- **Lane 2 (cont.) — README**: [`bin/postrun_sidecar/README.md`](../blob/feat/l-ddl-sidecar/bin/postrun_sidecar/README.md) — purpose, env vars table, TRI MCP `railway_service_deploy` invocation.

## Deploy manifest (Lane 3)

```json
{
  "service_name": "trios-postrun-sidecar",
  "image": "ghcr.io/ghashtag/trios-trainer-igla:latest",
  "env": {
    "RAILWAY_POSTGRES_URL": "${{phd-postgres-ssot.DATABASE_URL}}",
    "POLL_INTERVAL_S": "60",
    "ENTRYPOINT_OVERRIDE": "node bin/postrun_sidecar/migrate.ts && node bin/postrun_sidecar/index.js"
  },
  "project": "e4fe33bb-3b09-4842-9782-7d2dea1abc9b",
  "purpose": "ingest BPB rows from tier runners into ssot.bpb_samples; self-bootstraps schema on first run"
}
```

The manifest is also written to `/tmp/l-ddl-sidecar/SIDECAR_DEPLOY_MANIFEST.json` for the deploying operator.

## Files

| File | Lines | Type |
|------|------:|------|
| `migrations/2026-05-09_bpb_samples.sql` | 21 | DDL |
| `bin/postrun_sidecar/migrate.ts` | 96 | TypeScript |
| `bin/postrun_sidecar/README.md` | 53 | docs |
| **Total** | **170** | — |

## Constraints respected

- No new `.sh` files (CLAUDE.md L1).
- Migration is idempotent (`CREATE … IF NOT EXISTS` only).
- DB URL resolution preserves the `RAILWAY_POSTGRES_URL` → legacy `NEON_DATABASE_URL` precedence introduced by L-NEON-RENAME.
- No edits to existing files.
- Author: Dmitrii Vasilev <admin@t27.ai>; English only.
- No `--admin` merge.

## Anchor

`phi^2 + phi^-2 = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)