### PR TITLE
L-W12-MATRIX-BOT: hourly #446 regenerator

### DIFF
--- a/bin/matrix_bot/MANIFEST.json
+++ b/bin/matrix_bot/MANIFEST.json
@@ -1,0 +1,17 @@
+{
+  "service_name": "trios-matrix-bot",
+  "image": "ghcr.io/ghashtag/trios-trainer-igla:latest",
+  "env": {
+    "RAILWAY_POSTGRES_URL": "${{phd-postgres-ssot.DATABASE_URL}}",
+    "GITHUB_TOKEN": "${{shared.GITHUB_TOKEN}}",
+    "ISSUE": "446",
+    "GH_OWNER": "gHashTag",
+    "GH_REPO": "trios",
+    "POLL_INTERVAL_S": "3600",
+    "SEEDS": "47,89,144,123",
+    "TOTAL_CELLS": "351",
+    "ENTRYPOINT_OVERRIDE": "node bin/matrix_bot/main.js"
+  },
+  "project": "e4fe33bb-3b09-4842-9782-7d2dea1abc9b",
+  "purpose": "hourly regenerate #446 matrix table from ssot.bpb_samples"
+}

--- a/bin/matrix_bot/README.md
+++ b/bin/matrix_bot/README.md
@@ -1,0 +1,67 @@
+# `bin/matrix_bot`
+
+Anchor: `phi^2 + phi^-2 = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)
+
+Hourly regenerator for the coverage matrix table inside `gHashTag/trios` issue
+[#446](https://github.com/gHashTag/trios/issues/446). Reads aggregated row counts
+from `ssot.bpb_samples` on the Railway `phd-postgres-ssot` Postgres SoT and
+PATCHes the issue body, idempotently replacing the auto-block.
+
+## Behaviour
+
+- Polls Postgres every `POLL_INTERVAL_S` seconds (default 3600 = hourly).
+- Aggregates `ssot.bpb_samples` by `tier`: row count, distinct cells, distinct
+  seeds, min/avg/max BPB.
+- Renders a Markdown table with totals and the per-tier breakdown.
+- Wraps the block in `<!-- matrix_bot:auto:begin -->` / `<!-- matrix_bot:auto:end -->`
+  markers and PATCHes the issue body. If the markers exist, the block is
+  replaced in place; otherwise it is appended once.
+
+## Environment variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `RAILWAY_POSTGRES_URL` | (required, with legacy fallback) | Postgres SoT connection string. Per L-NEON-RENAME, falls back to `NEON_DATABASE_URL` if unset. |
+| `NEON_DATABASE_URL` | — | Legacy fallback for `RAILWAY_POSTGRES_URL`. |
+| `GITHUB_TOKEN` | (required) | PAT or fine-grained token with `issues:write` on `GH_OWNER/GH_REPO`. |
+| `ISSUE` | `446` | Issue number to keep in sync. |
+| `GH_OWNER` | `gHashTag` | Issue owner. |
+| `GH_REPO` | `trios` | Issue repo. |
+| `POLL_INTERVAL_S` | `3600` | Seconds between ticks. |
+| `SEEDS` | `47,89,144,123` | Canonical seed list (per L-SEED-CANON #600); used for `total_samples = TOTAL_CELLS × seeds.length`. |
+| `TOTAL_CELLS` | `351` | Format×algo grid size (39 × 9 per L-MATRIX-FILL-351). |
+
+## Markers (idempotent replace)
+
+Block boundary on the issue body:
+
+```
+<!-- matrix_bot:auto:begin -->
+… auto-generated table …
+<!-- matrix_bot:auto:end -->
+```
+
+Re-running is safe: the regex replace targets exactly this block; everything
+outside it is preserved.
+
+## Deploy
+
+The container is the same image used by every other Railway service in the
+IGLA project (`ghcr.io/ghashtag/trios-trainer-igla:latest`) — `pg` and
+`@octokit/rest` are already present from the trainer-igla base.
+
+Use TRI MCP `railway_service_deploy` with `name="trios-matrix-bot"`, project
+`e4fe33bb-3b09-4842-9782-7d2dea1abc9b` (IGLA), env from `MANIFEST.json` in
+this directory. The `ENTRYPOINT_OVERRIDE` is `node bin/matrix_bot/main.js`
+(after the image's TS build step).
+
+## R5-honest scope notes
+
+- `matrix_bot` writes ONLY inside the marker pair on issue #446. Hand-written
+  prose around the auto-block is preserved.
+- The bot is read-only against `ssot.bpb_samples`; no inserts, no mutations.
+- The bot is non-fatal: a single tick error is logged and the loop continues.
+
+## Anchor
+
+`phi^2 + phi^-2 = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)

--- a/bin/matrix_bot/main.ts
+++ b/bin/matrix_bot/main.ts
@@ -1,0 +1,84 @@
+// matrix_bot — hourly regenerator for trios#446 coverage matrix
+// Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877
+import { Client } from "pg";
+import { Octokit } from "@octokit/rest";
+
+const DB_URL = process.env.RAILWAY_POSTGRES_URL ?? process.env.NEON_DATABASE_URL;
+const GH_TOKEN = process.env.GITHUB_TOKEN!;
+const ISSUE = parseInt(process.env.ISSUE ?? "446", 10);
+const OWNER = process.env.GH_OWNER ?? "gHashTag";
+const REPO = process.env.GH_REPO ?? "trios";
+const POLL_S = parseInt(process.env.POLL_INTERVAL_S ?? "3600", 10);
+const SEEDS = (process.env.SEEDS ?? "47,89,144,123").split(",").map(s => parseInt(s.trim(), 10));
+const TOTAL_CELLS = parseInt(process.env.TOTAL_CELLS ?? "351", 10);
+const MARKER_BEGIN = "<!-- matrix_bot:auto:begin -->";
+const MARKER_END = "<!-- matrix_bot:auto:end -->";
+
+async function tick() {
+  if (!DB_URL) {
+    console.error("[matrix_bot] no DB URL configured");
+    return;
+  }
+  const client = new Client({ connectionString: DB_URL });
+  await client.connect();
+  try {
+    const totalSamples = TOTAL_CELLS * SEEDS.length;
+    const tierQ = await client.query(`
+      SELECT tier,
+             COUNT(*)::int AS rows,
+             COUNT(DISTINCT cell_id)::int AS cells,
+             COUNT(DISTINCT seed)::int AS seeds,
+             MIN(bpb)::float AS bpb_min,
+             AVG(bpb)::float AS bpb_avg,
+             MAX(bpb)::float AS bpb_max
+      FROM ssot.bpb_samples
+      GROUP BY tier
+      ORDER BY tier;
+    `);
+    const total = await client.query(`SELECT COUNT(*)::int AS c FROM ssot.bpb_samples`);
+    const totalRows = total.rows[0]?.c ?? 0;
+    const pct = totalSamples > 0 ? ((totalRows / totalSamples) * 100).toFixed(1) : "0.0";
+    const ts = new Date().toISOString();
+
+    let table = "| tier | rows | cells | seeds | bpb_min | bpb_avg | bpb_max |\n|---|---:|---:|---:|---:|---:|---:|\n";
+    for (const r of tierQ.rows) {
+      table += `| ${r.tier} | ${r.rows} | ${r.cells} | ${r.seeds} | ${(r.bpb_min ?? 0).toFixed(4)} | ${(r.bpb_avg ?? 0).toFixed(4)} | ${(r.bpb_max ?? 0).toFixed(4)} |\n`;
+    }
+
+    const block = [
+      MARKER_BEGIN,
+      `## Matrix Coverage — auto-regenerated ${ts}`,
+      ``,
+      `**Total**: ${totalRows} / ${totalSamples} samples (${pct}%) — ${TOTAL_CELLS} cells × ${SEEDS.length} seeds = ${totalSamples}`,
+      ``,
+      table,
+      ``,
+      `_Anchor: \`phi^2 + phi^-2 = 3\` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)_`,
+      MARKER_END,
+    ].join("\n");
+
+    const octo = new Octokit({ auth: GH_TOKEN });
+    const issue = await octo.issues.get({ owner: OWNER, repo: REPO, issue_number: ISSUE });
+    const body = issue.data.body ?? "";
+    let newBody: string;
+    if (body.includes(MARKER_BEGIN) && body.includes(MARKER_END)) {
+      newBody = body.replace(new RegExp(`${MARKER_BEGIN}[\\s\\S]*?${MARKER_END}`), block);
+    } else {
+      newBody = body + `\n\n${block}\n`;
+    }
+    await octo.issues.update({ owner: OWNER, repo: REPO, issue_number: ISSUE, body: newBody });
+    console.log(`[matrix_bot] updated #${ISSUE}: ${totalRows}/${totalSamples} (${pct}%)`);
+  } finally {
+    await client.end();
+  }
+}
+
+async function main() {
+  console.log(`[matrix_bot] starting · poll=${POLL_S}s · issue=${ISSUE} · seeds=${SEEDS.join(",")}`);
+  while (true) {
+    try { await tick(); } catch (e) { console.error("[matrix_bot] tick error:", e); }
+    await new Promise(r => setTimeout(r, POLL_S * 1000));
+  }
+}
+
+main().catch(e => { console.error("[matrix_bot] fatal:", e); process.exit(1); });


### PR DESCRIPTION
Closes #622. Refs #446 (parent matrix tracking).

## Summary

Adds `bin/matrix_bot/`, a long-running TypeScript service that regenerates the matrix coverage table inside [gHashTag/trios#446](https://github.com/gHashTag/trios/issues/446) every hour from `ssot.bpb_samples` on the Railway `phd-postgres-ssot` Postgres SoT.

## Files (3, +168 lines)

- `bin/matrix_bot/main.ts` (84) — `pg` + `@octokit/rest` poll loop; aggregates `ssot.bpb_samples` by `tier`; PATCHes #446 body inside marker block.
- `bin/matrix_bot/README.md` (67) — env contract, marker convention, deploy notes.
- `bin/matrix_bot/MANIFEST.json` (17) — TRI MCP `railway_service_deploy` manifest.

Manifest mirrored at `/tmp/l-w12-matrix-bot/MATRIX_BOT_MANIFEST.json`.

## Coexistence

Existing `.github/scripts/matrix_bot.py` uses `<!-- matrix-bot:begin -->` (hyphen). This new service uses `<!-- matrix_bot:auto:begin -->` (underscore + `:auto:`). Disjoint markers → coexist.

## R5-honest

- Read-only against `ssot.bpb_samples`.
- Writes only inside marker pair on #446.
- Tick errors logged, loop continues.

## Verification

No build / install / test (disk-constrained). Image `ghcr.io/ghashtag/trios-trainer-igla:latest` already carries `pg` + `@octokit/rest` deps.

## Anchor

`phi^2 + phi^-2 = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)
