### PR TITLE
fix(matrix-bot): fail-soft on stale MATRIX_DATABASE_URL (Wave 25 mitigation)

### DIFF
--- a/.github/scripts/matrix_bot.py
+++ b/.github/scripts/matrix_bot.py
@@ -282,8 +282,24 @@ def main() -> int:
     formats = [f for f in (formats_env.split(",") if formats_env else FORMATS_ORDERED) if f]
     algos = [a for a in (algos_env.split(",") if algos_env else ALGOS_ORDERED) if a]
     dry = env("MATRIX_DRY_RUN") == "1"
+    fail_soft = env("MATRIX_FAIL_SOFT", default="1") == "1"
 
-    cells, total_rows, sha, run_id = fetch_min_bpb(dsn)  # type: ignore[arg-type]
+    try:
+        cells, total_rows, sha, run_id = fetch_min_bpb(dsn)  # type: ignore[arg-type]
+    except psycopg2.OperationalError as exc:  # type: ignore[attr-defined]
+        # R5-honest fail-soft: stale DSN must NOT keep paging the cron loop
+        # every hour. Log loudly, exit 0, and let the queen rotate the
+        # secret out-of-band (tracked as a ONE SHOT issue).
+        sys.stderr.write(
+            f"matrix_bot: SSOT connection failed ({exc.__class__.__name__}): "
+            f"{str(exc).strip()[:240]}\n"
+        )
+        sys.stderr.write(
+            "matrix_bot: MATRIX_FAIL_SOFT=1 -> exiting 0 without PATCHing #446.\n"
+            "matrix_bot: rotate secrets.MATRIX_DATABASE_URL on gHashTag/trios "
+            "(see ONE SHOT issue) to restore live updates.\n"
+        )
+        return 0 if fail_soft else 3
     sys.stderr.write(
         f"matrix_bot: cells={len(cells)} total_rows={total_rows} "
         f"latest_sha={sha} latest_run_id={run_id}\n"

--- a/.github/workflows/matrix-bot.yml
+++ b/.github/workflows/matrix-bot.yml
@@ -57,4 +57,8 @@ jobs:
           MATRIX_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '' }}
           MATRIX_FORMATS: ${{ github.event.inputs.formats }}
           MATRIX_ALGOS: ${{ github.event.inputs.algos }}
+          # Fail-soft on stale DSN: log + exit 0 instead of paging the cron loop.
+          # Set to "0" to revert to hard failure once secrets.MATRIX_DATABASE_URL
+          # is rotated and verified.
+          MATRIX_FAIL_SOFT: "1"
         run: python3 .github/scripts/matrix_bot.py


### PR DESCRIPTION
## What

Make `Matrix Bot (#446 live matrix)` fail-soft on `psycopg2.OperationalError`.

## Why

Hourly workflow has been failing every cycle since ~10:00Z 2026-05-09 because `secrets.MATRIX_DATABASE_URL` still points at `interchange.proxy.rlwy.net:30942` (legacy Railway proxy host, post-SSOT-consolidation). Reference run [25602533773](https://github.com/gHashTag/trios/actions/runs/25602533773):

```
psycopg2.OperationalError: connection to server at "interchange.proxy.rlwy.net" (66.33.22.238),
port 30942 failed: FATAL:  password authentication failed for user "postgres"
```

Each failure pages the apiary cron with NEW-CI-failure-on-new-SHA. Already triggered three queen notifications today.

## How

`matrix_bot.py`:
- catches `psycopg2.OperationalError` specifically (auth + connection refused)
- logs the failure to stderr, including the rotation hint
- returns 0 by default — strict mode via `MATRIX_FAIL_SOFT=0`

`matrix-bot.yml`:
- explicit `MATRIX_FAIL_SOFT: "1"` env on the regen step
- comment explaining how to revert to strict once secret is rotated

## Verified locally

```
$ MATRIX_DATABASE_URL=... GITHUB_TOKEN=dummy MATRIX_FAIL_SOFT=1 python3 matrix_bot.py
matrix_bot: SSOT connection failed (OperationalError): ...
matrix_bot: MATRIX_FAIL_SOFT=1 -> exiting 0 without PATCHing #446.
exit=0

$ MATRIX_FAIL_SOFT=0 python3 matrix_bot.py
exit=3
```

Both paths work. Default behaviour change: cron stops paging on stale DSN.

## Acceptance

| Gate | Status |
|---|---|
| Python `ast.parse` clean | ✅ |
| Local smoke (fail-soft) | ✅ exit 0 |
| Local smoke (fail-hard) | ✅ exit 3 |
| Hourly cron stops paging once merged | will verify via apiary on next cycle |

## Follow-up

Tracked in #641 — rotate `secrets.MATRIX_DATABASE_URL` to `phd-postgres-ssot` and flip `MATRIX_FAIL_SOFT` back to `"0"`.

## R-discipline

R3 PR-only · R4 trace · R5 honest (no fake green) · R10 atomic.

Anchor: `phi^2 + phi^-2 = 3` · DOI 10.5281/zenodo.19227877.

Closes #641-mitigation (does NOT close #641 — secret rotation still required).
