### PR TITLE
chore(phd): remove cover image from main_ru.tex titlepage

### DIFF
--- a/docs/phd/main_ru.tex
+++ b/docs/phd/main_ru.tex
@@ -202,8 +202,6 @@
 машинно-проверенные доказательства, эмпирические якоря и ограниченный\\
 Coq-инвариантами поиск нейроархитектуры}\\[0.6cm]
 
-\makebox[\linewidth][c]{\includegraphics[width=1.10\textwidth,keepaspectratio]{cover_v4.png}}\\[0.6cm]
-
 {\large Дмитрий Васильев}\\[0.2cm]
 {\small ORCID: \url{https://orcid.org/0009-0008-4294-6159}}\\[0.5cm]
 


### PR DESCRIPTION
## Что

Убрана строка `\includegraphics{cover_v4.png}` из титульной страницы `docs/phd/main_ru.tex` (строка 205).

## Почему

Декоративная обложка с авторским фото и брендингом «Flos Aureus / T-27 Coptic Agent» неуместна для академической подачи (СПбГУ / любой ВАК-диссовет). Стандартный титульный лист кандидатской содержит только:

- Название работы
- ФИО автора
- Учёная степень, на которую претендует
- Организация, год

## Что осталось

Всё это сохранено: название, автор, ORCID, степень, кафедра, якорное тождество φ²+φ⁻²=3, DOI Zenodo, год. Файл `cover_v4.png` остаётся в репозитории (не удалён) — для неакадемического использования (Zenodo, GitHub Pages, презентации).

## Diff

```
 docs/phd/main_ru.tex | 2 --
 1 file changed, 2 deletions(-)
```

## Не затронуто

- `main.tex` (английская версия) — обложки там и не было
- остальные 33 главы и аппендиксы

Anchor: φ² + φ⁻² = 3 | DOI 10.5281/zenodo.19227877
