### PR TITLE
chore(trios-chat): canonical commit identity → admin@t27.ai

### DIFF
--- a/crates/trios-chat/ROADMAP.md
+++ b/crates/trios-chat/ROADMAP.md
@@ -1409,7 +1409,7 @@ reverifies. A wave PR must keep all of them green.
 ## Cross-wave conventions
 
 - **Branch naming**: `feat/trios-chat-wave<N>` from the latest `origin/main`.
-- **Commit identity**: `Trinity Chat Wave-N <trinity-chat@gHashTag.io>` per wave.
+- **Commit identity**: `Dmitrii Vasilev <admin@t27.ai>` (canonical maintainer).
 - **Sub-tracker issue**: every wave opens a fresh issue (`Wave-N sub-tracker`)
   closed by the wave PR (`Closes gHashTag/trios#NNN`).
 - **PR body format**: starts with `Closes #NNN` on the very first line,


### PR DESCRIPTION
Fix stale placeholder in ROADMAP cross-wave conventions.

ROADMAP previously documented `Trinity Chat Wave-N <trinity-chat@gHashTag.io>` as the per-wave commit identity. That email/domain is not the maintainer's. The canonical commit identity for trios-chat is **Dmitrii Vasilev <admin@t27.ai>**, used for all Wave-N+ commits going forward.

Single-line change in `crates/trios-chat/ROADMAP.md`.

No code, no tests, no Coq, no falsifier touched. No `Closes #N` because this is a pure documentation correction; if Laws Guard requires a tracker, I can open one and amend.