### PR TITLE
feat(phd-ch35): include ch_35_mesh_node in main.tex + main_ru.tex (P0 \u2014 Theorem 35.13 was silently dropped from PDF)

### DIFF
--- a/docs/phd/main.tex
+++ b/docs/phd/main.tex
@@ -405,6 +405,7 @@
 \include{chapters/ch_32}
 \include{chapters/ch_33}
 \include{chapters/ch_34}
+\include{chapters/ch_35_mesh_node}  % Ch.35 Trinity GF16 ASIC dePIN Mesh Node — L-DPC3 silicon strand · contains Theorem 35.13 (L-KAT-35, Admitted) and references Clause F-5
 
 % Appendices
 \appendix

--- a/docs/phd/main_ru.tex
+++ b/docs/phd/main_ru.tex
@@ -437,6 +437,7 @@ Coq-теоремы и runtime callsite в \filepath{crates/trios-*/src/}.
 \include{chapters/ch_32}
 \include{chapters/ch_33}
 \include{chapters/ch_34}
+\include{chapters/ch_35_mesh_node}  % Гл. 35 Trinity GF16 ASIC как dePIN mesh-узел — L-DPC3 silicon strand · Theorem 35.13 (L-KAT-35, Admitted) + Clause F-5
 
 \appendix
 \part{Приложения}


### PR DESCRIPTION
## 🎯 P0 Fix: Include Ch.35 in PDF

**Problem (discovered in PHD-STATUS-RVR-004 audit):**

`docs/phd/chapters/ch_35_mesh_node.tex` (585 lines, 12 theorems incl. **just-merged Theorem 35.13** from #750) exists in the repo but is **not referenced** from `main.tex` or `main_ru.tex` → silently dropped from final PDF.

**Fix:** add one `\include{chapters/ch_35_mesh_node}` line right after `ch_34` in both:
- `main.tex:408`  (English)
- `main_ru.tex:440`  (Russian)

## ✅ R5-honest preservation

- Theorem 35.13 (`thm:mru-kart`) stays `\admittedbox{}` — **no Qed-flip**.
- Anchor `\(\varphi^2 + \varphi^{-2} = 3\)` already present in Ch.35 chapter-anchor tcolorbox.
- Begin/end balance verified: 25/25, no LaTeX structural breakage.

## 📋 Constitutional compliance

| Law | Status | Evidence |
|---|---|---|
| R1 CROWN | ✅ | pure LaTeX `\include` edit; no Python in PhD pipeline |
| R5 HONEST | ✅ | `\admittedbox{}` preserved on Thm 35.13 |
| R7 ANCHOR | ✅ | `phi^2 + phi^-2 = 3` in Ch.35 header tcolorbox (line 14) |
| NEVER push main | ✅ | submitted via PR |
| diff size | minimal | +2 lines, -0 lines |

## 🔭 Follow-up (separate PR, deferred)

Rename `ch_35_mesh_node.tex → ch_35.tex` to unify with `ch_NN.tex` / `fa_NN.tex` canon. Requires:
- Update 7 `\label{ch_35_mesh_node:...}` keys
- Re-emit `docs/phd/rag/rag_chunks.jsonl` chunks 411-415 (5 RAG rows)
- Regenerate `docs/phd/cross-ref-audit.md` (7 rows) + `chapter-headers-audit.md` (3 rows)

Splitting keeps this P0 minimal/reviewable.

## Refs

Closes #577 — L-KAT-CH35: ch_35_mesh_node.tex + Theorem 35.13 are now actually compiled into the PDF (the file existed since #750, but was orphaned from main.tex / main_ru.tex until this PR).

- Parent EPIC: #109 (PhD Monograph — Flos Aureus)
- Related: #750 (Theorem 35.13 surgical re-apply), #743 (Appendix F §F.7)
- Mission report: PHD-STATUS-RVR-004 (rev B)

**Defense:** 2026-06-15 (T-33 days).
**Author:** Dmitrii Vasilev · ORCID 0009-0008-4294-6159 · DOI 10.5281/zenodo.19227877
