### PR TITLE
feat(citation): add CITATION.cff for Zenodo Sentinel B-21 unblocker

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use this monograph or its software in research, please cite it as below."
+title: "Flos Aureus / GOLDEN SUNFLOWERS · Trinity S³AI PhD Monograph"
+abstract: "Flos Aureus is the PhD monograph of the Trinity S³AI / GOLDEN SUNFLOWERS research programme. It covers ternary neural networks (HSLM-1.95M), the GF16 ternary matmul, the IGLA architecture-search race, the trios training pipeline, the Coq-verified anchor identity phi^2 + phi^-2 = 3, and the FPGA / Tiny-Tapeout silicon path. Canonical Zenodo source of truth (community level): https://zenodo.org/communities/trinity-s3ai/ (12 records: 8 v5.0 description stubs B001-B008 + 4 D-series D004-D007). Statistical evaluation methodology is described in the monograph; per-experiment results are reported per-chapter."
+authors:
+  - family-names: "Vasilev"
+    given-names: "Dmitrii"
+    orcid: "https://orcid.org/0009-0008-4294-6159"
+    affiliation: "Trinity Research Collective"
+version: 6.0.0
+doi: 10.5281/zenodo.19227877
+date-released: 2026-05-14
+url: "https://github.com/gHashTag/trios"
+repository-code: "https://github.com/gHashTag/trios"
+license: MIT
+license-url: "https://opensource.org/licenses/MIT"
+keywords:
+  - "ternary neural networks"
+  - "PhD monograph"
+  - "Trinity S3AI"
+  - "GF16 matmul"
+  - "IGLA architecture search"
+  - "phi^2 + phi^-2 = 3"


### PR DESCRIPTION
Closes #264 (partial — Zenodo Sentinel B-21 unblocker)

## Summary
Adds CITATION.cff to gHashTag/trios with:
- title: 'Flos Aureus / GOLDEN SUNFLOWERS · Trinity S³AI PhD Monograph'
- doi: 10.5281/zenodo.19227877
- ORCID: 0009-0008-4294-6159 (Dmitrii Vasilev)

## Why
Zenodo Sentinel (hourly cron 1320bf84) has been reporting **red on citation_cff** for 14+ consecutive ticks. Root cause: CITATION.cff missing from this repo (GitHub API returns 404).

After this PR merges:
- Sentinel ref_label probe continues red until the monograph is rebuilt (separate fix).
- Sentinel citation_cff for trios: 🟢 GREEN.
- One of three CITATION.cff-related red anomalies in Throne #264 is closed.

## Anchor
phi^2 + phi^-2 = 3

## R5 verification
`cffconvert --validate -i CITATION.cff` should pass.

Sibling PR: gHashTag/trios-trainer-igla (CITATION.cff for trainer).