### PR TITLE
feat(w38): nullor_witness.json — reversible dendritic NULLOR (Lane BB')

### DIFF
--- a/assertions/nullor_witness.json
+++ b/assertions/nullor_witness.json
@@ -1,0 +1,264 @@
+{
+  "wave": 38,
+  "name": "reversible_dendritic_nullor",
+  "anchor": "phi^2 + phi^-2 = 3",
+  "doi": "10.5281/zenodo.19227877",
+  "license": "Apache-2.0",
+  "author": "Vasilev Dmitrii <admin@t27.ai>",
+  "opcode": {
+    "name": "OP_NULL_PE",
+    "value": "0xE5",
+    "chain_range": "0xD0..0xE5",
+    "isa": "TRI-27"
+  },
+  "physics": {
+    "v_supply_v": 0.3,
+    "eta_reuse_target": 0.88,
+    "tops_per_w_estimate": 392,
+    "baseline_w37_tops_per_w": 350,
+    "gain_ratio": 1.12,
+    "landauer_kT_ln2_zj_at_300K": 17.9
+  },
+  "charge_reservoir_classes": [
+    {
+      "position": 0,
+      "register": "Ⲁ",
+      "charge_state": -1,
+      "capacitance_ff": 10.0,
+      "leakage_pa": 0.5
+    },
+    {
+      "position": 1,
+      "register": "Ⲃ",
+      "charge_state": 0,
+      "capacitance_ff": 10.1,
+      "leakage_pa": 0.55
+    },
+    {
+      "position": 2,
+      "register": "Ⲅ",
+      "charge_state": 1,
+      "capacitance_ff": 10.2,
+      "leakage_pa": 0.6
+    },
+    {
+      "position": 3,
+      "register": "Ⲇ",
+      "charge_state": -1,
+      "capacitance_ff": 10.3,
+      "leakage_pa": 0.65
+    },
+    {
+      "position": 4,
+      "register": "Ⲉ",
+      "charge_state": 0,
+      "capacitance_ff": 10.4,
+      "leakage_pa": 0.7
+    },
+    {
+      "position": 5,
+      "register": "Ⲋ",
+      "charge_state": 1,
+      "capacitance_ff": 10.5,
+      "leakage_pa": 0.75
+    },
+    {
+      "position": 6,
+      "register": "Ⲍ",
+      "charge_state": -1,
+      "capacitance_ff": 10.6,
+      "leakage_pa": 0.8
+    },
+    {
+      "position": 7,
+      "register": "Ⲏ",
+      "charge_state": 0,
+      "capacitance_ff": 10.7,
+      "leakage_pa": 0.85
+    },
+    {
+      "position": 8,
+      "register": "Ⲑ",
+      "charge_state": 1,
+      "capacitance_ff": 10.8,
+      "leakage_pa": 0.9
+    },
+    {
+      "position": 9,
+      "register": "Ⲓ",
+      "charge_state": -1,
+      "capacitance_ff": 10.9,
+      "leakage_pa": 0.95
+    },
+    {
+      "position": 10,
+      "register": "Ⲕ",
+      "charge_state": 0,
+      "capacitance_ff": 11.0,
+      "leakage_pa": 1.0
+    },
+    {
+      "position": 11,
+      "register": "Ⲗ",
+      "charge_state": 1,
+      "capacitance_ff": 11.1,
+      "leakage_pa": 1.05
+    },
+    {
+      "position": 12,
+      "register": "Ⲙ",
+      "charge_state": -1,
+      "capacitance_ff": 11.2,
+      "leakage_pa": 1.1
+    },
+    {
+      "position": 13,
+      "register": "Ⲛ",
+      "charge_state": 0,
+      "capacitance_ff": 11.3,
+      "leakage_pa": 1.15
+    },
+    {
+      "position": 14,
+      "register": "Ⲝ",
+      "charge_state": 1,
+      "capacitance_ff": 11.4,
+      "leakage_pa": 1.2
+    },
+    {
+      "position": 15,
+      "register": "Ⲟ",
+      "charge_state": -1,
+      "capacitance_ff": 11.5,
+      "leakage_pa": 1.25
+    },
+    {
+      "position": 16,
+      "register": "Ⲡ",
+      "charge_state": 0,
+      "capacitance_ff": 11.6,
+      "leakage_pa": 1.3
+    },
+    {
+      "position": 17,
+      "register": "Ⲣ",
+      "charge_state": 1,
+      "capacitance_ff": 11.7,
+      "leakage_pa": 1.35
+    },
+    {
+      "position": 18,
+      "register": "Ⲥ",
+      "charge_state": -1,
+      "capacitance_ff": 11.8,
+      "leakage_pa": 1.4
+    },
+    {
+      "position": 19,
+      "register": "Ⲧ",
+      "charge_state": 0,
+      "capacitance_ff": 11.9,
+      "leakage_pa": 1.45
+    },
+    {
+      "position": 20,
+      "register": "Ⲩ",
+      "charge_state": 1,
+      "capacitance_ff": 12.0,
+      "leakage_pa": 1.5
+    },
+    {
+      "position": 21,
+      "register": "Ⲫ",
+      "charge_state": -1,
+      "capacitance_ff": 12.1,
+      "leakage_pa": 1.55
+    },
+    {
+      "position": 22,
+      "register": "Ⲭ",
+      "charge_state": 0,
+      "capacitance_ff": 12.2,
+      "leakage_pa": 1.6
+    },
+    {
+      "position": 23,
+      "register": "Ⲯ",
+      "charge_state": 1,
+      "capacitance_ff": 12.3,
+      "leakage_pa": 1.65
+    },
+    {
+      "position": 24,
+      "register": "Ⲱ",
+      "charge_state": -1,
+      "capacitance_ff": 12.4,
+      "leakage_pa": 1.7
+    },
+    {
+      "position": 25,
+      "register": "Ϣ",
+      "charge_state": 0,
+      "capacitance_ff": 12.5,
+      "leakage_pa": 1.75
+    },
+    {
+      "position": 26,
+      "register": "Ϥ",
+      "charge_state": 1,
+      "capacitance_ff": 12.6,
+      "leakage_pa": 1.8
+    }
+  ],
+  "four_phase_clock": {
+    "phi_1_mhz": 400,
+    "phi_2_mhz": 300,
+    "phi_3_mhz": 200,
+    "phi_4_mhz": 100,
+    "non_overlap_ps": 50
+  },
+  "falsification": {
+    "id": "W-104-D",
+    "hypothesis": "eta_reuse >= 0.88 at V=0.30V implies measured TOPS/W >= 392 on TTIHP27a silicon return 2026-10-15",
+    "freeze_date": "2026-10-30",
+    "fail_stop": {
+      "tops_per_w_lt": 360,
+      "or_eta_reuse_lt": 0.8,
+      "action": "revert_w38"
+    }
+  },
+  "constitutional": {
+    "r_si_1": true,
+    "r5_honest": true,
+    "r8_admin_t27_ai": true,
+    "r15_opcode_monotonic": true,
+    "r18_layer_frozen": true
+  },
+  "lanes": [
+    {
+      "lane": "BB",
+      "repo": "t27",
+      "artifact": "trios-coq/Physics/NullorReversible.v"
+    },
+    {
+      "lane": "BB'",
+      "repo": "trios",
+      "artifact": "assertions/nullor_witness.json"
+    },
+    {
+      "lane": "BB''",
+      "repo": "tt-trinity-max-true",
+      "artifact": "crates/nullor-witness/"
+    },
+    {
+      "lane": "CC",
+      "repo": "trinity-fpga",
+      "artifact": "rtl/nullor/nullor_pe.sv"
+    },
+    {
+      "lane": "BB'''",
+      "repo": "trios",
+      "artifact": "docs/phd/chapters/glava_84_nullor.tex"
+    }
+  ]
+}


### PR DESCRIPTION
## Wave-38 Lane BB' — Reversible Dendritic NULLOR Assertion

Adds \`assertions/nullor_witness.json\` (264 lines) describing the reversible dendritic NULLOR with pre-registered falsification.

### Highlights
- **Opcode**: \`OP_NULL_PE = 0xE5\` (chain \`0xD0..0xE5\`, 18 opcodes, TRI-27 ISA)
- **Physics**: V=0.30V, η_reuse target ≥0.88, TOPS/W = 392 (×1.12 over W37 sub-V_T 350)
- **Charge reservoir**: 27 Coptic register classes (Ⲁ Ⲃ Ⲅ Ⲇ Ⲉ Ⲋ Ⲍ Ⲏ Ⲑ Ⲓ Ⲕ Ⲗ Ⲙ Ⲛ Ⲝ Ⲟ Ⲡ Ⲣ Ⲥ Ⲧ Ⲩ Ⲫ Ⲭ Ⲯ Ⲱ Ϣ Ϥ), deterministic charge_state cycle {-1,0,+1}
- **Clock**: 4-phase φ₁=400 / φ₂=300 / φ₃=200 / φ₄=100 MHz, 50 ps non-overlap
- **Falsification W-104-D**: freeze 2026-10-30, fail-stop if TOPS/W<360 or η_reuse<0.80 → revert_w38
- **Constitutional**: R-SI-1, R5, R8, R15, R18 all asserted

### Validation
\`\`\`
python3 -m json.tool < assertions/nullor_witness.json  # OK
\`\`\`

Anchor: φ² + φ⁻² = 3 · DOI: 10.5281/zenodo.19227877 · Apache-2.0

Closes trios#879