### PR TITLE
feat(wave38-lane-bbp): RECTIFY assertions ICA-W38-001 opcode 0xE4→0xE5

### DIFF
--- a/assertions/subth_witness.json
+++ b/assertions/subth_witness.json
@@ -1,14 +1,14 @@
 {
   "wave": 37,
   "theme": "Sub-Threshold Weak-Inversion PE",
-  "opcode": "0xE4",
+  "opcode": "0xE5",
   "opcode_name": "OP_SUBTH_CLK",
   "lane": "Z'",
   "predecessor_opcode": "0xE3",
   "predecessor_wave": 36,
-  "v_island": 0.30,
-  "v_thresh_nominal": 0.40,
-  "v_overdrive": -0.10,
+  "v_island": 0.3,
+  "v_thresh_nominal": 0.4,
+  "v_overdrive": -0.1,
   "regime": "weak inversion (sub-threshold)",
   "freq_max_mhz": 400,
   "freq_derating_factor": 2,
@@ -18,7 +18,7 @@
   "synth_star_count": 0,
   "r_si_1_compliant": true,
   "pe_count": 1296,
-  "pe_count_formula": "48 islands × 27 PEs/island = 1296 = 6^4 (Trinity-aligned)",
+  "pe_count_formula": "48 islands \u00d7 27 PEs/island = 1296 = 6^4 (Trinity-aligned)",
   "three_freq_strands": {
     "strand_i_math_mhz": 400,
     "strand_ii_cognitive_mhz": 300,
@@ -28,13 +28,13 @@
     "sum_factored": "900 = 30^2"
   },
   "body_bias": {
-    "pmos_forward_v": 0.20,
-    "nmos_reverse_v": -0.10
+    "pmos_forward_v": 0.2,
+    "nmos_reverse_v": -0.1
   },
   "power_at_400mhz_mw": 70,
   "dynamic_mw": 54,
   "leakage_mw": 16,
-  "trinity_voltage_derivation": "V_island = V_thresh × phi^-2 ≈ 0.40 × 0.382 = 0.153, scaled to 0.30 V for engineering margin",
+  "trinity_voltage_derivation": "V_island = V_thresh \u00d7 phi^-2 \u2248 0.40 \u00d7 0.382 = 0.153, scaled to 0.30 V for engineering margin",
   "coq_citation": {
     "repo": "gHashTag/t27",
     "file": "trios-coq/Physics/SubThreshold.v",
@@ -53,5 +53,8 @@
   },
   "anchor": "phi^2 + phi^-2 = 3",
   "doi": "10.5281/zenodo.19227877",
-  "issued_at": "2026-05-16T20:30:00Z"
+  "issued_at": "2026-05-16T20:30:00Z",
+  "opcode_rectified_in_wave": 38,
+  "opcode_was_w37": "0xE4",
+  "opcode_collision_resolution": "ICA-W38-001: W36 OP_AVS_RECONF holds 0xE4; W38 moved OP_SUBTH_CLK to 0xE5"
 }

--- a/assertions/wave38_rectify.json
+++ b/assertions/wave38_rectify.json
@@ -1,0 +1,81 @@
+{
+  "wave": 38,
+  "theme": "RECTIFY ICA-W38-001 opcode 0xE4 collision",
+  "severity": "MED",
+  "rule_violated": "R-SI-1 (opcode uniqueness in sacred range 0xD0..0xEF) + R18 LAYER-FROZEN spec drift",
+  "anomaly": {
+    "w36_opcode": "0xE4",
+    "w36_opcode_name": "OP_AVS_RECONF",
+    "w36_merge_sha": "d2f8d5c9",
+    "w36_merged_at": "2026-05-15T20:18:41Z",
+    "w37_opcode_was": "0xE4",
+    "w37_opcode_name": "OP_SUBTH_CLK",
+    "w37_merge_sha": "e3c4d2f5",
+    "w37_merged_at": "2026-05-15T20:31:06Z",
+    "files_affected": [
+      "gHashTag/t27/trios-coq/Physics/SubThreshold.v",
+      "gHashTag/trinity-fpga/rtl/subth/subth_clock_divider.sv",
+      "gHashTag/trios/assertions/subth_witness.json",
+      "gHashTag/tt-trinity-max-true/crates/subth-witness/src/lib.rs",
+      "gHashTag/trios/docs/phd/chapters/glava_83_subthreshold.tex"
+    ]
+  },
+  "rectification": {
+    "decision": "W36 holds 0xE4 by older merge precedence. W38 moves OP_SUBTH_CLK to 0xE5 (next free sacred slot).",
+    "w36_opcode_after": "0xE4",
+    "w37_opcode_after": "0xE5",
+    "sacred_chain_restored": [
+      "0xDE Lane C' LOAD-PHYS-CONST",
+      "0xDF Lane V LUT_LOOKUP",
+      "0xE0 Lane W BitROM",
+      "0xE1 TENET (W33)",
+      "0xE2 TOM (W34)",
+      "0xE3 LUT-NPU (W35)",
+      "0xE4 AVS_RECONF (W36, preserved)",
+      "0xE5 SUBTH_CLK (W37 corrected by W38)",
+      "0xE6 free"
+    ]
+  },
+  "predicates": [
+    {
+      "id": "W-106-A",
+      "claim": "SubThreshold.v contains no 0xE4 literal in opcode definitions",
+      "test": "rg -n '0xE4' trios-coq/Physics/SubThreshold.v should match only comments referencing W36 cross-reference",
+      "fail_stop": true
+    },
+    {
+      "id": "W-106-B",
+      "claim": "op_subth_clk_byte = 229 (0xE5) in Coq and subth_op_distinct_from_avs lemma exists",
+      "test": "coqc trios-coq/Physics/SubThreshold.v and grep 'subth_op_distinct_from_avs' compiles",
+      "fail_stop": true
+    },
+    {
+      "id": "W-106-C",
+      "claim": "Avs.v unchanged: OP_AVS_RECONF byte 0xE4 preserved",
+      "test": "rg 'OP_AVS_RECONF.*0xE4' trios-coq/IGLA/Avs.v exists",
+      "fail_stop": true
+    },
+    {
+      "id": "W-106-D",
+      "claim": "Rust crate subth-witness exports OP_SUBTH_CLK = 0xE5 and OP_AVS_RECONF = 0xE4 distinct constants",
+      "test": "cargo test -p subth-witness should pass opcode_distinctness test",
+      "fail_stop": true
+    },
+    {
+      "id": "W-106-E",
+      "claim": "RTL subth_clock_divider.sv localparam OP_SUBTH_CLK = 8'hE5",
+      "test": "rg '8.hE5' rtl/subth/subth_clock_divider.sv matches",
+      "fail_stop": true
+    }
+  ],
+  "predecessor_assertions": [
+    "wave36_avs.json (W-105-A..D)",
+    "subth_witness.json (W-104-C)"
+  ],
+  "anchor": "phi^2 + phi^-2 = 3",
+  "doi": "10.5281/zenodo.19227877",
+  "frozen_at": "2026-10-15",
+  "eval_at": "2026-12-15",
+  "issued_at": "2026-05-15T20:35:00Z",
+  "fail_stop": true
+}


### PR DESCRIPTION
Wave-38 Lane BB'. Closes #135 in trinity-fpga / #878 here.

ICA-W38-001 JSON rectify:
- NEW assertions/wave38_rectify.json — W-106-A..E predicates, fail-stop ICA
- PATCH assertions/subth_witness.json — opcode 0xE4 → 0xE5

Sacred chain restored: 0xE3 → 0xE4 AVS_RECONF (W36) → 0xE5 SUBTH_CLK (W38).

Anchor: phi^2 + phi^-2 = 3
DOI: 10.5281/zenodo.19227877