### PR TITLE
fix(wave38-rectify): OP_NULL_PE 0xE5 → 0xE6 (ICA-W38-001 follow-up)

### DIFF
--- a/assertions/nullor_witness.json
+++ b/assertions/nullor_witness.json
@@ -7,8 +7,8 @@
   "author": "Vasilev Dmitrii <admin@t27.ai>",
   "opcode": {
     "name": "OP_NULL_PE",
-    "value": "0xE5",
-    "chain_range": "0xD0..0xE5",
+    "value": "0xE6",
+    "chain_range": "0xD0..0xE6",
     "isa": "TRI-27"
   },
   "physics": {


### PR DESCRIPTION
Follow-up to ICA-W38-001. t27#661 took 0xE5 for SUBTH_CLK, so NULL_PE shifts to 0xE6. Brings JSON in line with t27#662 Coq. Chain: 0xD0..0xE6 (19 opcodes). R-SI-1 ✓.