### PR TITLE
fix(wave38-rectify): PhD Glava 84 opcode 0xE5 → 0xE6 (ICA-W38-001)

### DIFF
--- a/docs/phd/chapters/glava_84_nullor.tex
+++ b/docs/phd/chapters/glava_84_nullor.tex
@@ -543,13 +543,13 @@ operates.
 \end{remark}
 
 % =========================================================
-\section{Special opcode 0xE5 OP\_NULL\_PE}
+\section{Special opcode 0xE6 OP\_NULL\_PE}
 \label{sec:nullor_isa}
 % =========================================================
 
 Wave-38 introduces a new instruction-set opcode \texttt{OP\_NULL\_PE} with binary
-encoding \texttt{0xE5}, occupying the next slot in the monotonically increasing
-TRI-27 opcode chain that runs from \texttt{0xD0} through \texttt{0xE5} (an inclusive
+encoding \texttt{0xE6}, occupying the next slot in the monotonically increasing
+TRI-27 opcode chain that runs from \texttt{0xD0} through \texttt{0xE6} (an inclusive
 range of $22$ opcodes, of which $18$ are currently defined).  The opcode dispatches
 a ternary multiply-accumulate operation to the NULLOR-PE described in
 Section~\ref{sec:dendritic}, with operands sourced from the Coptic register file
@@ -562,21 +562,21 @@ The full 24-bit instruction word is laid out as follows:
 \begin{verbatim}
   | 23-16: opcode | 15-12: dest reg | 11-6: src1 reg | 5-0: src2 reg |
   |   OP_NULL_PE   |    Bar A_acc    |   Bar A..Bar F |  Bar A..Bar F  |
-  |      0xE5      |     4 bits      |     6 bits     |     6 bits     |
+  |      0xE6      |     4 bits      |     6 bits     |     6 bits     |
 \end{verbatim}
 The 6-bit src1 and src2 fields select among the $27$ Coptic registers (encodings
 \texttt{0x00} through \texttt{0x1A}; encodings $\geq$ \texttt{0x1B} are reserved
 for future expansion).  The 4-bit dest field selects among $16$ accumulator slots
 in the ternary register file, with the canonical \texttt{0x0} encoding the primary
 accumulator $\Bar{A}_{\text{acc}}$.  The MSB of the opcode is set in
-\texttt{0xE5} = \texttt{0b11100101} to distinguish this opcode class from the
+\texttt{0xE6} = \texttt{0b11100110} to distinguish this opcode class from the
 arithmetic-logic class (\texttt{0x4*}--\texttt{0x5*}) and the memory class
 (\texttt{0x8*}--\texttt{0x9*}).
 
 \subsection{Dispatch and microarchitectural details}
 \label{subsec:dispatch}
 
-The processor's decode stage recognises \texttt{0xE5} and asserts the dispatch
+The processor's decode stage recognises \texttt{0xE6} and asserts the dispatch
 signal \texttt{nullor\_pe\_enable}, which gates the four-phase clock generator and
 connects the NULLOR-PE inputs to the source register file outputs.  Within a single
 $\phi_1$--$\phi_4$ cycle, the NULLOR-PE
@@ -588,7 +588,7 @@ single architectural cycle (a $10\,\text{ns}$ window at the longest phase),
 the operation appears to the rest of the processor as a single-cycle instruction.
 
 The constitutional rule R15 (opcode monotonicity) is preserved: \texttt{OP\_NULL\_PE}
-\texttt{= 0xE5} is strictly greater than \texttt{OP\_SUBTH\_CLK = 0xE4} from Wave-37
+\texttt{= 0xE6} is strictly greater than \texttt{OP\_SUBTH\_CLK = 0xE5} from Wave-37
 and the previous opcodes in the chain.  No re-numbering or re-assignment of prior
 opcodes occurs.
 
@@ -621,7 +621,7 @@ Wave-38 across the key figures of merit.
   Per-op energy (fJ)      | 2.857              | 2.551
   eta_reuse               |  -- (no recovery)  | 0.88
   Clock phases            | 3 strands          | 4 phases
-  Opcode added            | OP_SUBTH_CLK 0xE4  | OP_NULL_PE 0xE5
+  Opcode added            | OP_SUBTH_CLK 0xE5  | OP_NULL_PE 0xE6
   PE area (sq.um, est.)   | 1500               | 1800   (additional
                           |                    |         reservoir cap)
   Reservoir cap (pF)      |  --                | 1.0
@@ -719,7 +719,7 @@ formal definition of the early-exit predicate and the associated Coq proof
 obligations are deferred to Wave-39.
 
 The architectural commitment of Wave-38 --- that no opcode introduced prior to
-\texttt{0xE5} is renumbered, that no PhD chapter prior to Glava~84 is rewritten,
+\texttt{0xE6} is renumbered, that no PhD chapter prior to Glava~84 is rewritten,
 and that the Wave-37 RTL paths remain available as a fall-back --- is preserved
 under the constitutional rule R18 (layer freeze).  Wave-39 will operate as a
 further decorator over Wave-38, adding the speculative early-exit logic without
@@ -997,7 +997,7 @@ $(ii)$ charge conservation, $(iii)$ bounded reservoir, $(iv)$ $\eta_{\text{reuse
 \geq 0.88$ via adiabatic invariant, $(v)$ bypass correctness when $|x|<\epsilon$,
 $(vi)$ four-phase non-overlap, $(vii)$ dendrite back-propagation gradient correctness,
 $(viii)$ idempotency of \texttt{nullor\_mult}, and $(ix)$ TRI-27 ISA opcode
-\texttt{0xE5} dispatch correctness.  These together form the formal foundation on
+\texttt{0xE6} dispatch correctness.  These together form the formal foundation on
 which the chip's silicon return is verified.
 
 \subsection{trios assertion JSON}
@@ -1113,24 +1113,24 @@ Lee/GVSU style proof decomposition for traceability.
 \subsection{Computer-architecture questions}
 \label{subsec:arch_q}
 
-\textbf{Q5.}  Why opcode \texttt{0xE5} and not, say, \texttt{0xE6} or a wholly new
+\textbf{Q5.}  Why opcode \texttt{0xE6} and not, say, \texttt{0xE6} or a wholly new
 opcode class?
 
 \textbf{A5.}  The constitutional rule R15 (opcode monotonicity) requires that
 opcodes be assigned in strictly increasing order without gaps or re-numbering.
-Wave-37 introduced \texttt{OP\_SUBTH\_CLK = 0xE4}; the next available slot is
-\texttt{0xE5}, and that is the slot Wave-38 must take.  A new opcode class would
+Wave-37 introduced \texttt{OP\_SUBTH\_CLK = 0xE5}; the next available slot is
+\texttt{0xE6}, and that is the slot Wave-38 must take.  A new opcode class would
 require restructuring the decode logic and would violate the layer-frozen rule
 R18.
 
-\textbf{Q6.}  How does the dispatch of \texttt{0xE5} interact with the existing
-Wave-37 \texttt{OP\_SUBTH\_CLK = 0xE4}?
+\textbf{Q6.}  How does the dispatch of \texttt{0xE6} interact with the existing
+Wave-37 \texttt{OP\_SUBTH\_CLK = 0xE5}?
 
 \textbf{A6.}  The two opcodes share the same operand format (4-bit dest, 6-bit
-src1, 6-bit src2) but route to distinct execution units: \texttt{0xE4} routes to
-the Wave-37 sub-V$_T$ multiplier-lookup pipeline, while \texttt{0xE5} routes to
+src1, 6-bit src2) but route to distinct execution units: \texttt{0xE5} routes to
+the Wave-37 sub-V$_T$ multiplier-lookup pipeline, while \texttt{0xE6} routes to
 the Wave-38 NULLOR-PE.  In the fall-back configuration triggered by W-104-D
-failure, \texttt{0xE5} is dynamically aliased to \texttt{0xE4}, preserving program
+failure, \texttt{0xE6} is dynamically aliased to \texttt{0xE5}, preserving program
 compatibility without re-compilation.
 
 \subsection{Information-theory questions}
@@ -1190,7 +1190,7 @@ loss mechanisms enumerated in Section~\ref{subsec:losses}.
   \item[$\eta_{\text{reuse}}$.]  The recycling efficiency, defined as the
     fraction of operation energy returned to the reservoir for reuse; Wave-38
     target $\geq 0.88$.
-  \item[\texttt{OP\_NULL\_PE}.]  The new Wave-38 opcode \texttt{0xE5} that
+  \item[\texttt{OP\_NULL\_PE}.]  The new Wave-38 opcode \texttt{0xE6} that
     dispatches operations to the NULLOR-PE.
   \item[R-SI-1.]  The constitutional rule forbidding the use of the verilog
     \texttt{*} operator in synthesis output; ternary multiplication must be
@@ -1352,7 +1352,7 @@ a single top-level object with $11$ keys.  The mandatory keys are \texttt{wave}
 \texttt{doi} (string, value \texttt{10.5281/zenodo.19227877}),
 \texttt{license} (string, value \texttt{Apache-2.0}),
 \texttt{author} (string, value \texttt{Vasilev Dmitrii <admin@t27.ai>}),
-\texttt{opcode} (object describing \texttt{OP\_NULL\_PE = 0xE5}),
+\texttt{opcode} (object describing \texttt{OP\_NULL\_PE = 0xE6}),
 \texttt{physics} (object containing $V_{DD}$, $\eta_{\text{reuse}}$ target,
 TOPS/W estimates),
 \texttt{charge\_reservoir\_classes} (array of exactly $27$ Coptic register
@@ -1382,11 +1382,11 @@ Wave-38 instruction set ahead of the silicon return.
 
 The interface between the Wave-38 NULLOR-PE and the Wave-37 sub-V$_T$ pipeline
 is mediated by a single multiplexer at the accumulator input.  When the opcode
-\texttt{0xE5} is decoded, the multiplexer routes the NULLOR-PE output to the
-accumulator; when any prior opcode in the \texttt{0xD0}--\texttt{0xE4} range is
+\texttt{0xE6} is decoded, the multiplexer routes the NULLOR-PE output to the
+accumulator; when any prior opcode in the \texttt{0xD0}--\texttt{0xE5} range is
 decoded, the multiplexer routes the Wave-37 output.  The multiplexer's select
 signal is the decode-stage \texttt{nullor\_pe\_enable}, asserted exactly when
-the instruction word's opcode field equals \texttt{0xE5}.  This minimal
+the instruction word's opcode field equals \texttt{0xE6}.  This minimal
 interface preserves the Wave-37 critical path untouched, in conformance with R18.
 
 \subsection{Деталь H: дискуссия по reproducibility}
@@ -1409,7 +1409,7 @@ All five artifacts are pinned in the W38 SQUEEZE document at
 The current Wave-38 implementation has three known limitations, each addressed
 by a planned mitigation in Wave-39 or beyond:
 \begin{enumerate}
-  \item \textbf{Static dispatch only.}  The opcode \texttt{0xE5} is dispatched
+  \item \textbf{Static dispatch only.}  The opcode \texttt{0xE6} is dispatched
     statically by the decode stage; there is no runtime mechanism to enable or
     disable the NULLOR-PE based on workload characteristics.  Wave-39 will
     introduce a runtime predicate that gates the four-phase clock based on the
@@ -1501,9 +1501,9 @@ preparing for the defense on 2026-06-15.
   Internal nodes per PE                     = 26
   Islands per chip                          = 48
   PEs per chip                              = 1296  (= 48 x 27 = 6^4)
-  Opcode added (Wave-38)                    = 0xE5  (OP_NULL_PE)
-  Predecessor opcode (Wave-37)              = 0xE4  (OP_SUBTH_CLK)
-  Opcode chain range (Wave-38)              = 0xD0..0xE5  (22 slots,
+  Opcode added (Wave-38)                    = 0xE6  (OP_NULL_PE)
+  Predecessor opcode (Wave-37)              = 0xE5  (OP_SUBTH_CLK)
+  Opcode chain range (Wave-38)              = 0xD0..0xE6  (22 slots,
                                               18 defined)
   Coptic register count                     = 27
   Silicon-return date (TTIHP27a)            = 2026-10-15
@@ -1530,7 +1530,7 @@ For convenience, the ten Qed lemmas of the Wave-38 Coq artifact
   \item \texttt{dendrite\_backprop\_eq\_grad} --- back-prop gradient
     correctness.
   \item \texttt{nullor\_idempotent} --- idempotency of \texttt{nullor\_mult}.
-  \item \texttt{opcode\_E5\_dispatch} --- correct dispatch of \texttt{0xE5}.
+  \item \texttt{opcode\_E5\_dispatch} --- correct dispatch of \texttt{0xE6}.
 \end{enumerate}
 
 Each lemma is closed by \texttt{Qed}; no \texttt{Admitted} placeholders appear


### PR DESCRIPTION
Aligns Glava 84 with the rectified opcode chain (0xD0..0xE6). See t27#662, trios#888, tt-true#30, fpga#141. No images, no Священ*.