### PR TITLE
feat(w39 Lane DD'): spec_exit_witness.json — speculative early-exit assertion

### DIFF
--- a/assertions/spec_exit_witness.json
+++ b/assertions/spec_exit_witness.json
@@ -1,0 +1,267 @@
+{
+  "wave": 39,
+  "name": "speculative_early_exit",
+  "anchor": "phi^2 + phi^-2 = 3",
+  "doi": "10.5281/zenodo.19227877",
+  "license": "Apache-2.0",
+  "author": "Vasilev Dmitrii <admin@t27.ai>",
+  "opcode": {
+    "name": "OP_SPEC_EXIT",
+    "value": "0xE7",
+    "chain_range": "0xD0..0xE7",
+    "isa": "TRI-27"
+  },
+  "physics": {
+    "phi_inv_threshold": 0.6180339887,
+    "avg_exit_depth_target_fraction": 0.42,
+    "tops_per_w_estimate": 470,
+    "baseline_w38_tops_per_w": 392,
+    "gain_ratio": 1.2,
+    "overhead_speculation_fraction_max": 0.5
+  },
+  "three_strand_vote": {
+    "strand_fast_mhz": 400,
+    "strand_mid_mhz": 300,
+    "strand_slow_mhz": 200,
+    "quorum": "2_of_3"
+  },
+  "exit_depth_bins_27": [
+    {
+      "bin_index": 0,
+      "register": "Ⲁ",
+      "depth_fraction_lo": 0.0,
+      "depth_fraction_hi": 0.037037,
+      "expected_population": 0.01383
+    },
+    {
+      "bin_index": 1,
+      "register": "Ⲃ",
+      "depth_fraction_lo": 0.037037,
+      "depth_fraction_hi": 0.074074,
+      "expected_population": 0.019362
+    },
+    {
+      "bin_index": 2,
+      "register": "Ⲅ",
+      "depth_fraction_lo": 0.074074,
+      "depth_fraction_hi": 0.111111,
+      "expected_population": 0.024894
+    },
+    {
+      "bin_index": 3,
+      "register": "Ⲇ",
+      "depth_fraction_lo": 0.111111,
+      "depth_fraction_hi": 0.148148,
+      "expected_population": 0.030425
+    },
+    {
+      "bin_index": 4,
+      "register": "Ⲉ",
+      "depth_fraction_lo": 0.148148,
+      "depth_fraction_hi": 0.185185,
+      "expected_population": 0.035957
+    },
+    {
+      "bin_index": 5,
+      "register": "Ⲋ",
+      "depth_fraction_lo": 0.185185,
+      "depth_fraction_hi": 0.222222,
+      "expected_population": 0.041489
+    },
+    {
+      "bin_index": 6,
+      "register": "Ⲍ",
+      "depth_fraction_lo": 0.222222,
+      "depth_fraction_hi": 0.259259,
+      "expected_population": 0.047021
+    },
+    {
+      "bin_index": 7,
+      "register": "Ⲏ",
+      "depth_fraction_lo": 0.259259,
+      "depth_fraction_hi": 0.296296,
+      "expected_population": 0.052553
+    },
+    {
+      "bin_index": 8,
+      "register": "Ⲑ",
+      "depth_fraction_lo": 0.296296,
+      "depth_fraction_hi": 0.333333,
+      "expected_population": 0.058085
+    },
+    {
+      "bin_index": 9,
+      "register": "Ⲓ",
+      "depth_fraction_lo": 0.333333,
+      "depth_fraction_hi": 0.37037,
+      "expected_population": 0.063617
+    },
+    {
+      "bin_index": 10,
+      "register": "Ⲕ",
+      "depth_fraction_lo": 0.37037,
+      "depth_fraction_hi": 0.407407,
+      "expected_population": 0.069149
+    },
+    {
+      "bin_index": 11,
+      "register": "Ⲗ",
+      "depth_fraction_lo": 0.407407,
+      "depth_fraction_hi": 0.444444,
+      "expected_population": 0.074681
+    },
+    {
+      "bin_index": 12,
+      "register": "Ⲙ",
+      "depth_fraction_lo": 0.444444,
+      "depth_fraction_hi": 0.481481,
+      "expected_population": 0.069149
+    },
+    {
+      "bin_index": 13,
+      "register": "Ⲛ",
+      "depth_fraction_lo": 0.481481,
+      "depth_fraction_hi": 0.518519,
+      "expected_population": 0.063617
+    },
+    {
+      "bin_index": 14,
+      "register": "Ⲝ",
+      "depth_fraction_lo": 0.518519,
+      "depth_fraction_hi": 0.555556,
+      "expected_population": 0.058085
+    },
+    {
+      "bin_index": 15,
+      "register": "Ⲟ",
+      "depth_fraction_lo": 0.555556,
+      "depth_fraction_hi": 0.592593,
+      "expected_population": 0.052553
+    },
+    {
+      "bin_index": 16,
+      "register": "Ⲡ",
+      "depth_fraction_lo": 0.592593,
+      "depth_fraction_hi": 0.62963,
+      "expected_population": 0.047021
+    },
+    {
+      "bin_index": 17,
+      "register": "Ⲣ",
+      "depth_fraction_lo": 0.62963,
+      "depth_fraction_hi": 0.666667,
+      "expected_population": 0.041489
+    },
+    {
+      "bin_index": 18,
+      "register": "Ⲥ",
+      "depth_fraction_lo": 0.666667,
+      "depth_fraction_hi": 0.703704,
+      "expected_population": 0.035957
+    },
+    {
+      "bin_index": 19,
+      "register": "Ⲧ",
+      "depth_fraction_lo": 0.703704,
+      "depth_fraction_hi": 0.740741,
+      "expected_population": 0.030425
+    },
+    {
+      "bin_index": 20,
+      "register": "Ⲩ",
+      "depth_fraction_lo": 0.740741,
+      "depth_fraction_hi": 0.777778,
+      "expected_population": 0.024894
+    },
+    {
+      "bin_index": 21,
+      "register": "Ⲫ",
+      "depth_fraction_lo": 0.777778,
+      "depth_fraction_hi": 0.814815,
+      "expected_population": 0.019362
+    },
+    {
+      "bin_index": 22,
+      "register": "Ⲭ",
+      "depth_fraction_lo": 0.814815,
+      "depth_fraction_hi": 0.851852,
+      "expected_population": 0.01383
+    },
+    {
+      "bin_index": 23,
+      "register": "Ⲯ",
+      "depth_fraction_lo": 0.851852,
+      "depth_fraction_hi": 0.888889,
+      "expected_population": 0.008298
+    },
+    {
+      "bin_index": 24,
+      "register": "Ⲱ",
+      "depth_fraction_lo": 0.888889,
+      "depth_fraction_hi": 0.925926,
+      "expected_population": 0.002766
+    },
+    {
+      "bin_index": 25,
+      "register": "Ϣ",
+      "depth_fraction_lo": 0.925926,
+      "depth_fraction_hi": 0.962963,
+      "expected_population": 0.000747
+    },
+    {
+      "bin_index": 26,
+      "register": "Ϥ",
+      "depth_fraction_lo": 0.962963,
+      "depth_fraction_hi": 1.0,
+      "expected_population": 0.000747
+    }
+  ],
+  "misprediction_recovery": {
+    "latency_cycles": 1,
+    "mechanism": "W38_trinity_bypass_diode"
+  },
+  "falsification": {
+    "id": "W-104-E",
+    "hypothesis": "avg exit depth <= 0.45 * full AND speculation overhead <= 0.50 implies measured TOPS/W >= 470 on TTIHP27a return 2026-10-15",
+    "freeze_date": "2026-11-15",
+    "fail_stop": {
+      "tops_per_w_lt": 430,
+      "or_avg_exit_depth_gt": 0.55,
+      "action": "revert_w39"
+    }
+  },
+  "constitutional": {
+    "r_si_1": true,
+    "r5_honest": true,
+    "r8_admin_t27_ai": true,
+    "r15_opcode_monotonic": true,
+    "r18_layer_frozen": true
+  },
+  "lanes": [
+    {
+      "lane": "DD",
+      "repo": "t27",
+      "artifact": "trios-coq/Physics/SpeculativeExit.v"
+    },
+    {
+      "lane": "DD'",
+      "repo": "trios",
+      "artifact": "assertions/spec_exit_witness.json"
+    },
+    {
+      "lane": "DD''",
+      "repo": "tt-trinity-max-true",
+      "artifact": "crates/spec-exit-witness/"
+    },
+    {
+      "lane": "EE",
+      "repo": "trinity-fpga",
+      "artifact": "rtl/spec_exit/spec_exit_pipeline.sv"
+    },
+    {
+      "lane": "DD'''",
+      "repo": "trios",
+      "artifact": "docs/phd/chapters/glava_85_speculative_exit.tex"
+    }
+  ]
+}


### PR DESCRIPTION
## Wave-39 Lane DD' — Speculative Early-Exit JSON Witness

Adds `assertions/spec_exit_witness.json` (267 lines, valid JSON).

### Highlights
- **OP_SPEC_EXIT = 0xE7** (chain 0xD0..0xE7, 20 opcodes; extends W38 0xE6 NULL_PE)
- **TOPS/W target 470** (×1.20 over W38=392)
- **27 Coptic exit-depth bins** Ⲁ..Ϥ, triangular distribution peaked at bin 11 (≈0.42 mean), Σ ≈ 1.0
- **W-104-E falsification**: avg_exit_depth≤0.45 ∧ overhead≤0.50 ⇒ TOPS/W≥470 on TTIHP27a return 2026-10-15, freeze 2026-11-15
- **2-of-3 strand vote** (400/300/200 MHz quorum)
- **1-cycle misprediction recovery** via W38 trinity bypass diode
- φ⁻¹ confidence threshold (0.6180339887)

### Gates
- JSON valid: `python3 -m json.tool` ✓
- Σ expected_population = 1.000003 (within 1e-3 tolerance) ✓
- Commit signed admin@t27.ai (R8)
- Apache-2.0, anchor φ²+φ⁻²=3, DOI 10.5281/zenodo.19227877

Closes trios#890

Cross-repo: trinity-fpga#142