### PR TITLE
feat(w42): wave42_stoch.json (Sacred 0xE9)

### DIFF
--- a/assertions/wave42_stoch.json
+++ b/assertions/wave42_stoch.json
@@ -1,0 +1,18 @@
+{
+  "wave": 42,
+  "codename": "STOCHASTIC-ROUNDING-INT4",
+  "sacred_opcode": "0xE9",
+  "opcode_name": "OP_STOCH_ROUND",
+  "tops_w_projection": {"pre": 762, "post": 820, "lift_pct": 7.6, "target_ihp22fdx": 756, "headroom_pct": 8.5},
+  "anchor": "phi^2 + phi^-2 = 3",
+  "doi": "10.5281/zenodo.19227877",
+  "biology_ref": "Hubara2018,Gupta2015",
+  "assertions": [
+    {"id": "W-110-A", "type": "coq_lemma", "name": "stoch_op_distinct_from_sparse",     "file": "trios-coq/Physics/StochRound.v", "expected": "Qed"},
+    {"id": "W-110-B", "type": "coq_lemma", "name": "stoch_op_distinct_from_dfs",         "file": "trios-coq/Physics/StochRound.v", "expected": "Qed"},
+    {"id": "W-110-C", "type": "coq_lemma", "name": "stoch_unbiased_count",               "file": "trios-coq/Physics/StochRound.v", "expected": "Qed"},
+    {"id": "W-110-D", "type": "rtl_assert", "name": "lfsr_max_period",                   "file": "rtl/lfsr32.sv",                   "expected": "PASS"},
+    {"id": "W-110-E", "type": "rtl_assert", "name": "stoch_empirical_unbiased_xfrac_8",  "file": "rtl/stoch_round.sv",              "expected": "PASS"},
+    {"id": "W-110-F", "type": "rust_test", "name": "test_opcode_e9_constant",            "file": "crates/stoch-round-witness/tests/opcode.rs", "expected": "PASS"}
+  ]
+}


### PR DESCRIPTION
Closes #899

W-110-A..F assertion rows for Hardware Stochastic Rounding INT4.

φ²+φ⁻²=3 · DOI 10.5281/zenodo.19227877