### PR TITLE
feat(w40 Lane FF'): sparsity_witness.json — trinity loss-aware sparsity W-104-F

### DIFF
--- a/assertions/sparsity_witness.json
+++ b/assertions/sparsity_witness.json
@@ -1,0 +1,212 @@
+{
+  "wave": 40,
+  "name": "trinity_loss_aware_sparsity",
+  "anchor": "phi^2 + phi^-2 = 3",
+  "doi": "10.5281/zenodo.19227877",
+  "license": "Apache-2.0",
+  "author": "Vasilev Dmitrii <admin@t27.ai>",
+  "opcode": {
+    "name": "OP_SPARSE_MASK",
+    "value": "0xE8",
+    "chain_range": "0xD0..0xE8",
+    "isa": "TRI-27"
+  },
+  "physics": {
+    "sparsity_ratio_target": 0.8,
+    "lambda_golden": 0.3819660113,
+    "tops_per_w_estimate": 540,
+    "baseline_w39_tops_per_w": 470,
+    "gain_ratio": 1.149,
+    "mask_control_overhead_max": 0.3,
+    "depth_fraction_w39": 0.42,
+    "width_fraction_w40": 0.2,
+    "combined_compute_fraction": 0.084
+  },
+  "three_strand_sensitivity": {
+    "strand_fast": "magnitude",
+    "strand_mid": "gradient_norm_proxy",
+    "strand_slow": "co_activation_entropy",
+    "quorum": "2_of_3"
+  },
+  "coptic_27_mask_groups": [
+    {
+      "group_index": 0,
+      "channel_count": 32,
+      "expected_prune_ratio": 0.8
+    },
+    {
+      "group_index": 1,
+      "channel_count": 36,
+      "expected_prune_ratio": 0.8042
+    },
+    {
+      "group_index": 2,
+      "channel_count": 40,
+      "expected_prune_ratio": 0.8045
+    },
+    {
+      "group_index": 3,
+      "channel_count": 44,
+      "expected_prune_ratio": 0.8007
+    },
+    {
+      "group_index": 4,
+      "channel_count": 32,
+      "expected_prune_ratio": 0.7962
+    },
+    {
+      "group_index": 5,
+      "channel_count": 36,
+      "expected_prune_ratio": 0.7952
+    },
+    {
+      "group_index": 6,
+      "channel_count": 40,
+      "expected_prune_ratio": 0.7986
+    },
+    {
+      "group_index": 7,
+      "channel_count": 44,
+      "expected_prune_ratio": 0.8033
+    },
+    {
+      "group_index": 8,
+      "channel_count": 32,
+      "expected_prune_ratio": 0.8049
+    },
+    {
+      "group_index": 9,
+      "channel_count": 36,
+      "expected_prune_ratio": 0.8021
+    },
+    {
+      "group_index": 10,
+      "channel_count": 40,
+      "expected_prune_ratio": 0.7973
+    },
+    {
+      "group_index": 11,
+      "channel_count": 44,
+      "expected_prune_ratio": 0.795
+    },
+    {
+      "group_index": 12,
+      "channel_count": 32,
+      "expected_prune_ratio": 0.7973
+    },
+    {
+      "group_index": 13,
+      "channel_count": 36,
+      "expected_prune_ratio": 0.8021
+    },
+    {
+      "group_index": 14,
+      "channel_count": 40,
+      "expected_prune_ratio": 0.805
+    },
+    {
+      "group_index": 15,
+      "channel_count": 44,
+      "expected_prune_ratio": 0.8033
+    },
+    {
+      "group_index": 16,
+      "channel_count": 32,
+      "expected_prune_ratio": 0.7986
+    },
+    {
+      "group_index": 17,
+      "channel_count": 36,
+      "expected_prune_ratio": 0.7952
+    },
+    {
+      "group_index": 18,
+      "channel_count": 40,
+      "expected_prune_ratio": 0.7962
+    },
+    {
+      "group_index": 19,
+      "channel_count": 44,
+      "expected_prune_ratio": 0.8007
+    },
+    {
+      "group_index": 20,
+      "channel_count": 32,
+      "expected_prune_ratio": 0.8046
+    },
+    {
+      "group_index": 21,
+      "channel_count": 36,
+      "expected_prune_ratio": 0.8042
+    },
+    {
+      "group_index": 22,
+      "channel_count": 40,
+      "expected_prune_ratio": 0.8
+    },
+    {
+      "group_index": 23,
+      "channel_count": 44,
+      "expected_prune_ratio": 0.7958
+    },
+    {
+      "group_index": 24,
+      "channel_count": 32,
+      "expected_prune_ratio": 0.7955
+    },
+    {
+      "group_index": 25,
+      "channel_count": 36,
+      "expected_prune_ratio": 0.7993
+    },
+    {
+      "group_index": 26,
+      "channel_count": 40,
+      "expected_prune_ratio": 0.8038
+    }
+  ],
+  "falsification": {
+    "id": "W-104-F",
+    "hypothesis": "s >= 0.78 AND mask-control overhead <= 0.30 implies measured TOPS/W >= 540 on TTIHP27a return 2026-10-15",
+    "freeze_date": "2026-11-30",
+    "fail_stop": {
+      "tops_per_w_lt": 490,
+      "or_accuracy_drop_bpb_gt": 1.5,
+      "action": "revert_w40"
+    }
+  },
+  "constitutional": {
+    "r_si_1": true,
+    "r5_honest": true,
+    "r8_admin_t27_ai": true,
+    "r15_opcode_monotonic": true,
+    "r18_layer_frozen": true
+  },
+  "lanes": [
+    {
+      "lane": "FF",
+      "repo": "t27",
+      "artifact": "trios-coq/Physics/SparsityMask.v"
+    },
+    {
+      "lane": "FF'",
+      "repo": "trios",
+      "artifact": "assertions/sparsity_witness.json"
+    },
+    {
+      "lane": "FF''",
+      "repo": "tt-trinity-max-true",
+      "artifact": "crates/sparsity-witness/"
+    },
+    {
+      "lane": "GG",
+      "repo": "trinity-fpga",
+      "artifact": "rtl/sparsity/sparse_pe_mask.sv"
+    },
+    {
+      "lane": "FF'''",
+      "repo": "trios",
+      "artifact": "docs/phd/chapters/glava_91_sparsity.tex"
+    }
+  ]
+}


### PR DESCRIPTION
## Wave-40 Lane FF' — Trinity Loss-Aware Sparsity Witness

Pure-JSON pre-registration of falsification **W-104-F**.

### Highlights
- **OP_SPARSE_MASK = 0xE8** (chain 0xD0..0xE8, 21 opcodes; succeeds W39 0xE7 SPEC_EXIT)
- **lambda_golden = phi^-2 ~ 0.3819660113** (L_total = L_task + lambda * sparsity_loss)
- **27 Coptic mask groups**: channel_count cycles {32,36,40,44}; expected_prune_ratio = clamp(0.80 + 0.005*sin(i), [0.75, 0.85])
- **Three-strand sensitivity**: magnitude (fast) / gradient_norm_proxy (mid) / co_activation_entropy (slow); 2-of-3 quorum
- **TOPS/W >= 540** (x1.149 over W39 = 470)
- **combined_compute_fraction = 0.42 * 0.20 = 0.084** (depth x width)
- **Falsification W-104-F**: silicon return 2026-10-15, freeze 2026-11-30, fail_stop on TOPS/W<490 OR delta_bpb>1.5

Closes #906

Anchor: phi^2 + phi^-2 = 3 -- DOI: 10.5281/zenodo.19227877