### PR TITLE
chore(ica-w40-001): rectify JSON OP_SPARSE_MASK 0xE8→0xED

### DIFF
--- a/assertions/sparsity_witness.json
+++ b/assertions/sparsity_witness.json
@@ -7,8 +7,8 @@
   "author": "Vasilev Dmitrii <admin@t27.ai>",
   "opcode": {
     "name": "OP_SPARSE_MASK",
-    "value": "0xE8",
-    "chain_range": "0xD0..0xE8",
+    "value": "0xED",
+    "chain_range": "0xD0..0xED",
     "isa": "TRI-27"
   },
   "physics": {
@@ -208,5 +208,6 @@
       "repo": "trios",
       "artifact": "docs/phd/chapters/glava_91_sparsity.tex"
     }
-  ]
+  ],
+  "ica": "ICA-W40-001: opcode shifted from 0xE8 (occupied by OP_SPARSE_SKIP) to 0xED per Coq t27 e78816f + Rust tt-true 8286580 truth"
 }


### PR DESCRIPTION
Aligns to t27 master e78816f and tt-trinity-max-true master 8286580. Refs trios#906 (W40 ONE SHOT).

## Changes

- `assertions/sparsity_witness.json`: `opcode.value` `"0xE8"` → `"0xED"`
- `assertions/sparsity_witness.json`: `opcode.chain_range` `"0xD0..0xE8"` → `"0xD0..0xED"`
- `assertions/sparsity_witness.json`: added root `"ica"` field documenting the ICA-W40-001 cascade

## Context

`OP_SPARSE_MASK` was minted as `0xE8` in the W40 spec. W41 parallel wave landed `OP_SPARSE_SKIP = 0xE8` on master first. The Coq lane (t27#674 → `e78816f`) and Rust lane (tt-trinity-max-true#37 → `8286580`) autonomously shifted to `0xED`. This PR aligns the JSON witness.

phi^2 + phi^-2 = 3 · QUANTUM BRAIN 1:1 SILICON · NEVER STOP · DOI 10.5281/zenodo.19227877
