### PR TITLE
build(ci): unblock cargo test --all on main (autobins + INV-7 duplicate tests) (Closes #944)

### DIFF
--- a/crates/trios-igla-race/src/victory_new.rs
+++ b/crates/trios-igla-race/src/victory_new.rs
@@ -600,9 +600,11 @@ mod tests {
         }
     }
 
-    /// Falsification 3: duplicate seed rejected.
+    /// Falsification 3 (INV-7): duplicate seed rejected.
+    /// Companion to `falsify_duplicate_seed` above; kept under a
+    /// distinct name to avoid E0428 after the INV-7 set was merged in.
     #[test]
-    fn falsify_duplicate_seed() {
+    fn falsify_duplicate_seed_inv7() {
         let r = vec![
             SeedResult { seed: 42, bpb: 1.40, step: 5000, sha: "a".into() },
             SeedResult { seed: 42, bpb: 1.41, step: 5000, sha: "b".into() },
@@ -655,18 +657,23 @@ mod tests {
         }
     }
 
-    /// Falsification 6: non-finite BPB rejected.
+    /// Falsification 6 (INV-7): non-finite BPB rejected.
+    /// Companion to `falsify_non_finite_bpb` above; kept under a
+    /// distinct name to avoid E0428 after the INV-7 set was merged in.
     #[test]
-    fn falsify_non_finite_bpb() {
+    fn falsify_non_finite_bpb_inv7() {
         for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             let r = vec![
                 SeedResult { seed: 42, bpb: bad, step: 5000, sha: "a".into() },
                 SeedResult { seed: 43, bpb: 1.45, step: 5000, sha: "b".into() },
                 SeedResult { seed: 44, bpb: 1.39, step: 5000, sha: "c".into() },
             ];
+            // The bad value lives on seed=42 in this set (the INV-7
+            // companion uses raw seed numbers, not the mk() helper
+            // which maps to seed=1). Pin the actual seed under test.
             match check_victory(&r) {
-                Err(VictoryError::NonFiniteBpb { seed: 1, .. }) => {}
-                other => panic!("expected NonFiniteBpb for {bad}, got {other:?}"),
+                Err(VictoryError::NonFiniteBpb { seed: 42, .. }) => {}
+                other => panic!("expected NonFiniteBpb for seed=42, {bad}, got {other:?}"),
             }
         }
     }

--- a/crates/trios-train-cpu/Cargo.toml
+++ b/crates/trios-train-cpu/Cargo.toml
@@ -2,6 +2,13 @@
 name = "trios-train-cpu"
 version = "0.1.0"
 edition = "2021"
+# T-JEPA training binaries in src/bin/ depend on modules
+# (jepa, objective, MuonOptimizer, AdamW, NgramModel, …) that
+# are not yet implemented in this crate. Disable Cargo bin
+# auto-discovery until the training stack is restored so the
+# workspace `cargo test --all` keeps compiling. Tracked by
+# the upstream T-JEPA owner; see ROADMAP.
+autobins = false
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Closes #944

## What

Two-step unblock of workspace `cargo test --all`:

1. **Disable bin auto-discovery for `trios-train-cpu`** — `crates/trios-train-cpu/Cargo.toml` gains `autobins = false`. The 5 files in `src/bin/` (main + 4 helpers) all import a T-JEPA module tree (`jepa`, `objective`, `MuonOptimizer`, `AdamW`, `NgramModel`, `JepaPredictor`, `PredictorConfig`, `NcaObjective`, `Config`, `OptKind`, `EmaTarget`, `EmaConfig`, `ObjectiveConfig`, `ComponentLosses`, `build_span_mask`, `compute_combined_loss`) that does not exist in this crate. Lib (`mup`, `schedule`) keeps compiling and shipping.
2. **Rename INV-7 duplicate test fns in `trios-igla-race::victory_new`** — `falsify_duplicate_seed` and `falsify_non_finite_bpb` were each defined twice in the same `mod tests` block (botched merge between Trinity Identity tests using `mk()` helper and INV-7 tests using raw `SeedResult` literals). Rename the INV-7 versions to `*_inv7` so both sets coexist. Also fix a latent seed=42 vs seed=1 mismatch in `falsify_non_finite_bpb_inv7`.

## Why

Pre-existing on main since `41fc97f` / earlier — `CI / Test` (required) and `Laws Guard / Nine Kingdoms Verification` (required) red on every commit. Blocks every downstream PR (e.g. #942 / W33 trios-chat).

## Diff

```toml
# crates/trios-train-cpu/Cargo.toml
+autobins = false
```

```rust
// crates/trios-igla-race/src/victory_new.rs
-fn falsify_duplicate_seed() {     // second occurrence, line 605
+fn falsify_duplicate_seed_inv7() {

-fn falsify_non_finite_bpb() {     // second occurrence, line 660
+fn falsify_non_finite_bpb_inv7() {
-    Err(VictoryError::NonFiniteBpb { seed: 1, .. }) => {}
+    Err(VictoryError::NonFiniteBpb { seed: 42, .. }) => {}
```

## What this is NOT

- **Not** implementing the missing `jepa`/`objective`/optimizer modules — that's the T-JEPA owner's job (tracked in #944).
- **Not** deleting bin source — files stay on disk for the real fix.
- **Not** touching `lib.rs` (`mup` + `schedule` continue to compile as before).
- **Not** changing INV-7 test semantics — both companion tests run independently after the rename.

## Verification (post-merge expectation)

- `crates/trios-train-cpu` lib: 2 pre-existing warnings only (in `schedule.rs:34` / `:81`).
- Workspace `cargo test --all` → no longer hits broken `trios-train-cpu` bins, no longer hits E0428 duplicates → CI/Test and Nine-Kingdoms go green.

## Impact

Once merged → PR #942 (W33 trios-chat) and any other branch held up by CI/Test unblock.

---

🤖 Generated with [Perplexity Computer](https://perplexity.ai)

Co-Authored-By: Trinity Grandmaster <admin@t27.ai>